### PR TITLE
feat(baoyu-post-to-wechat): add screenshot capture on login issues

### DIFF
--- a/skills/baoyu-post-to-wechat/scripts/wechat-article.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-article.ts
@@ -28,11 +28,39 @@ interface ArticleOptions {
   cdpPort?: number;
 }
 
-async function waitForLogin(session: ChromeSession, timeoutMs = 120_000): Promise<boolean> {
+async function captureAndNotify(cdp: CdpConnection, sessionId: string, reason: string): Promise<string> {
+  console.log(`[wechat] Capturing screenshot: ${reason}`);
+  try {
+    const screenshot = await cdp.send<{ data: string }>('Page.captureScreenshot',
+      { format: 'png' },
+      { sessionId }
+    );
+    const screenshotPath = `/tmp/wechat-${reason}-${Date.now()}.png`;
+    fs.writeFileSync(screenshotPath, Buffer.from(screenshot.data, 'base64'));
+
+    console.log(`PLEASE_UPLOAD_TO_DISCORD: ${screenshotPath}`);
+    return screenshotPath;
+  } catch (err) {
+    console.error(`[wechat] Screenshot failed: ${err instanceof Error ? err.message : String(err)}`);
+    return '';
+  }
+}
+
+async function waitForLogin(session: ChromeSession, timeoutMs = 600_000): Promise<boolean> {
   const start = Date.now();
+  console.log(`[wechat] Waiting for login (timeout: ${timeoutMs / 1000}s)...`);
+
   while (Date.now() - start < timeoutMs) {
     const url = await evaluate<string>(session, 'window.location.href');
-    if (url.includes('/cgi-bin/home')) return true;
+    if (url.includes('/cgi-bin/home')) {
+      console.log('[wechat] Login detected!');
+      return true;
+    }
+
+    if ((Date.now() - start) % 30000 < 2000) {
+      console.log(`[wechat] Still waiting... (${Math.floor((Date.now() - start) / 1000)}s elapsed)`);
+    }
+
     await sleep(2000);
   }
   return false;
@@ -329,6 +357,26 @@ export async function postArticle(options: ArticleOptions): Promise<void> {
           await evaluate(session, `window.location.href = '${WECHAT_URL}cgi-bin/home?t=home/index'`);
           await sleep(5000);
         }
+
+        // Verify login is still valid by checking for menu element
+        const menuExists = await waitForElement(session, '.new-creation__menu', 5000);
+        if (!menuExists && currentUrl.includes('/cgi-bin/')) {
+          console.log('[wechat] Tab appears logged in but menu not found, session may be expired...');
+          await evaluate(session, 'window.location.reload()');
+          await sleep(5000);
+
+          const stillNoMenu = !(await waitForElement(session, '.new-creation__menu', 5000));
+          if (stillNoMenu) {
+            console.log('[wechat] Session expired, capturing login screen...');
+            await captureAndNotify(cdp, session.sessionId, 'session-expired');
+
+            const loggedIn = await waitForLogin(session, 600_000);
+            if (!loggedIn) {
+              await captureAndNotify(cdp, session.sessionId, 'login-timeout');
+              throw new Error('Login timeout after session expiration');
+            }
+          }
+        }
       } else {
         // No WeChat tab found, create one
         console.log('[wechat] No WeChat tab found, opening...');
@@ -342,9 +390,18 @@ export async function postArticle(options: ArticleOptions): Promise<void> {
 
     const url = await evaluate<string>(session, 'window.location.href');
     if (!url.includes('/cgi-bin/')) {
-      console.log('[wechat] Not logged in. Please scan QR code...');
-      const loggedIn = await waitForLogin(session);
-      if (!loggedIn) throw new Error('Login timeout');
+      console.log('[wechat] Not logged in, capturing login screen...');
+
+      await captureAndNotify(cdp, session.sessionId, 'login-required');
+
+      console.log('[wechat] Please scan QR code in the Chrome window...');
+      console.log('[wechat] Will wait up to 10 minutes for login...');
+
+      const loggedIn = await waitForLogin(session, 600_000);
+      if (!loggedIn) {
+        await captureAndNotify(cdp, session.sessionId, 'login-timeout');
+        throw new Error('Login timeout after 10 minutes');
+      }
     }
     console.log('[wechat] Logged in.');
     await sleep(2000);


### PR DESCRIPTION
## Summary

This PR enhances the login handling in `baoyu-post-to-wechat` by adding automatic screenshot capture when login is required or fails. This significantly improves the remote execution workflow where Claude Code is called from a Discord bot via cloud API and local worker.

## Changes

### New Features
- **Screenshot capture function**: Added `captureAndNotify()` to capture browser screenshots via Chrome DevTools Protocol
- **Extended login timeout**: Increased from 2 minutes to 10 minutes to accommodate remote users
- **Progress logging**: Added periodic status updates during login wait (every 30 seconds)
- **Enhanced login verification**: Check for menu element existence to verify session validity

### Improvements
- Capture screenshots on three scenarios:
  - `login-required`: When initial login is needed
  - `session-expired`: When reused Chrome tab has expired session
  - `login-timeout`: When login wait times out
- Output `PLEASE_UPLOAD_TO_DISCORD: /path/to/screenshot.png` marker for external tools (Discord bots, monitoring systems) to detect and upload screenshots
- Handle session expiration gracefully in Chrome tab reuse workflow

## Use Case

This feature is designed for remote execution scenarios:
```
Discord User → Discord Bot → Cloud API → Local Worker → Claude Code → Chrome
```

When WeChat login is required, the screenshot is automatically captured and the path is output with a special marker. The worker/bot can then:
1. Parse the marker from stdout
2. Read the screenshot file
3. Upload to Discord/notification channel
4. Notify user to scan QR code

## Testing

- ✅ Tested with local execution
- ✅ Screenshot files created successfully in `/tmp/`
- ✅ Special marker output correctly in stdout
- ✅ Login timeout extended to 10 minutes works as expected

## Related

This addresses login stability issues in remote execution environments, especially when users are away from their Mac and cannot immediately scan QR codes.

---

🤖 Generated with Claude Code