### PR TITLE
fix(baoyu-post-to-wechat): fix title and list number duplication in WeChat articles

### DIFF
--- a/skills/baoyu-post-to-wechat/scripts/md-to-wechat.ts
+++ b/skills/baoyu-post-to-wechat/scripts/md-to-wechat.ts
@@ -120,22 +120,28 @@ export async function convertMarkdown(markdownPath: string, options?: { title?: 
   const { frontmatter, body } = parseFrontmatter(content);
 
   let title = options?.title ?? frontmatter.title ?? '';
+  let bodyWithoutTitle = body;
   if (!title) {
     const lines = body.split('\n');
     for (const line of lines) {
       const trimmed = line.trim();
       if (!trimmed) continue;
       const headingMatch = trimmed.match(/^#{1,2}\s+(.+)$/);
-      if (headingMatch) title = headingMatch[1]!;
+      if (headingMatch) {
+        title = headingMatch[1]!;
+        bodyWithoutTitle = body.replace(/^#{1,2}\s+.+\r?\n?/, '');
+      }
       break;
     }
+  } else {
+    bodyWithoutTitle = body.replace(/^#{1,2}\s+.+\r?\n?/, '');
   }
   if (!title) title = path.basename(markdownPath, path.extname(markdownPath));
   const author = frontmatter.author || '';
   let summary = frontmatter.description || frontmatter.summary || '';
 
   if (!summary) {
-    const lines = body.split('\n');
+    const lines = bodyWithoutTitle.split('\n');
     for (const line of lines) {
       const trimmed = line.trim();
       if (!trimmed) continue;
@@ -161,7 +167,7 @@ export async function convertMarkdown(markdownPath: string, options?: { title?: 
   const images: Array<{ src: string; placeholder: string }> = [];
   let imageCounter = 0;
 
-  const modifiedBody = body.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, src) => {
+  const modifiedBody = bodyWithoutTitle.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, src) => {
     const placeholder = `WECHATIMGPH_${++imageCounter}`;
     images.push({ src, placeholder });
     return placeholder;

--- a/skills/baoyu-post-to-wechat/scripts/md/render.ts
+++ b/skills/baoyu-post-to-wechat/scripts/md/render.ts
@@ -374,7 +374,7 @@ export function initRenderer(opts: IOpts = {}): RendererAPI {
 
       listCounters[listCounters.length - 1] = idx + 1;
 
-      const prefix = ordered ? `${idx}. ` : "• ";
+      const prefix = ordered ? "" : "• ";
 
       let content: string;
       try {


### PR DESCRIPTION
## Summary
- Fix duplicate title display in WeChat articles (title appeared both in header and content body)
- Fix duplicate list numbering (1.1., 2.2., 3.3. → 1., 2., 3.)

## Changes

### `scripts/md-to-wechat.ts`
Remove title line from body content after extracting it for the WeChat title field.

### `scripts/md/render.ts`  
Remove manual ordered list prefix since HTML `<ol>` already provides numbering.

## Related Issue
Closes #35

## Test
Tested locally with multiple WeChat articles - both issues are now fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)