### PR TITLE
add EXTEND.md configuration support

### DIFF
--- a/skills/baoyu-image-gen/SKILL.md
+++ b/skills/baoyu-image-gen/SKILL.md
@@ -41,7 +41,9 @@ test -f "$HOME/.baoyu-skills/baoyu-image-gen/EXTEND.md" && echo "user"
 │ Not found │ Use defaults                                                              │
 └───────────┴───────────────────────────────────────────────────────────────────────────┘
 
-**EXTEND.md Supports**: Default provider | Default quality | Default aspect ratio
+**EXTEND.md Supports**: Default provider | Default quality | Default aspect ratio | Default image size | Default models
+
+Schema: `references/config/preferences-schema.md`
 
 ## Usage
 
@@ -99,7 +101,7 @@ npx -y bun ${SKILL_DIR}/scripts/main.ts --prompt "一只可爱的猫" --image ou
 | `GOOGLE_BASE_URL` | Custom Google endpoint |
 | `DASHSCOPE_BASE_URL` | Custom DashScope endpoint |
 
-**Load Priority**: CLI args > env vars > `<cwd>/.baoyu-skills/.env` > `~/.baoyu-skills/.env`
+**Load Priority**: CLI args > EXTEND.md > env vars > `<cwd>/.baoyu-skills/.env` > `~/.baoyu-skills/.env`
 
 ## Provider Selection
 

--- a/skills/baoyu-image-gen/references/config/preferences-schema.md
+++ b/skills/baoyu-image-gen/references/config/preferences-schema.md
@@ -1,0 +1,66 @@
+---
+name: preferences-schema
+description: EXTEND.md YAML schema for baoyu-image-gen user preferences
+---
+
+# Preferences Schema
+
+## Full Schema
+
+```yaml
+---
+version: 1
+
+default_provider: null      # google|openai|dashscope|null (null = auto-detect)
+
+default_quality: null       # normal|2k|null (null = use default: 2k)
+
+default_aspect_ratio: null  # "16:9"|"1:1"|"4:3"|"3:4"|"2.35:1"|null
+
+default_image_size: null    # 1K|2K|4K|null (Google only, overrides quality)
+
+default_model:
+  google: null              # e.g., "gemini-3-pro-image-preview"
+  openai: null              # e.g., "gpt-image-1.5"
+  dashscope: null           # e.g., "z-image-turbo"
+---
+```
+
+## Field Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `version` | int | 1 | Schema version |
+| `default_provider` | string\|null | null | Default provider (null = auto-detect) |
+| `default_quality` | string\|null | null | Default quality (null = 2k) |
+| `default_aspect_ratio` | string\|null | null | Default aspect ratio |
+| `default_image_size` | string\|null | null | Google image size (overrides quality) |
+| `default_model.google` | string\|null | null | Google default model |
+| `default_model.openai` | string\|null | null | OpenAI default model |
+| `default_model.dashscope` | string\|null | null | DashScope default model |
+
+## Examples
+
+**Minimal**:
+```yaml
+---
+version: 1
+default_provider: google
+default_quality: 2k
+---
+```
+
+**Full**:
+```yaml
+---
+version: 1
+default_provider: google
+default_quality: 2k
+default_aspect_ratio: "16:9"
+default_image_size: 2K
+default_model:
+  google: "gemini-3-pro-image-preview"
+  openai: "gpt-image-1.5"
+  dashscope: "z-image-turbo"
+---
+```

--- a/skills/baoyu-image-gen/scripts/types.ts
+++ b/skills/baoyu-image-gen/scripts/types.ts
@@ -9,10 +9,23 @@ export type CliArgs = {
   model: string | null;
   aspectRatio: string | null;
   size: string | null;
-  quality: Quality;
+  quality: Quality | null;
   imageSize: string | null;
   referenceImages: string[];
   n: number;
   json: boolean;
   help: boolean;
+};
+
+export type ExtendConfig = {
+  version: number;
+  default_provider: Provider | null;
+  default_quality: Quality | null;
+  default_aspect_ratio: string | null;
+  default_image_size: "1K" | "2K" | "4K" | null;
+  default_model: {
+    google: string | null;
+    openai: string | null;
+    dashscope: string | null;
+  };
 };


### PR DESCRIPTION
# Add EXTEND.md Configuration Support for baoyu-image-gen

## Summary

- Add EXTEND.md configuration file support, allowing users to set default values for provider, quality, aspect ratio, image size, and models
- Support both project-level (`.baoyu-skills/baoyu-image-gen/EXTEND.md`) and user-level (`~/.baoyu-skills/baoyu-image-gen/EXTEND.md`) configurations
- Implemented with custom YAML parser, no external dependencies required
- Configuration priority: CLI args > EXTEND.md > env vars > .env files

## Changes

- **types.ts**: Add `ExtendConfig` type definition, change `quality` to nullable type
- **main.ts**: Implement EXTEND.md loading, parsing, and configuration merging logic
- **SKILL.md**: Update documentation for supported configuration options and loading priority
- **references/config/preferences-schema.md**: Add configuration schema documentation

## Benefits

- Users no longer need to pass the same CLI arguments every time
- Support for both project-level and user-level configurations provides greater flexibility
- Zero external dependencies, keeping the project lightweight

## Example

```yaml
---
version: 1
default_provider: google
default_quality: 2k
default_aspect_ratio: "16:9"
default_model:
  google: "gemini-3-pro-image-preview"
---
```