### PR TITLE
feat(baoyu-xhs-images): add reference image chain for visual consistency

### DIFF
--- a/skills/baoyu-xhs-images/SKILL.md
+++ b/skills/baoyu-xhs-images/SKILL.md
@@ -368,10 +368,21 @@ Display the selected style's default elements from preset, then ask:
 
 With confirmed outline + style + layout:
 
+**Visual Consistency — Reference Image Chain**:
+To ensure character/style consistency across all images in a series:
+1. **Generate image 1 (cover) FIRST** — without `--ref`
+2. **Use image 1 as `--ref` for ALL remaining images** (2, 3, ..., N)
+   - This anchors the character design, color rendering, and illustration style
+   - Command pattern: `--ref <path-to-image-01.png>` added to every subsequent generation
+
+This is critical for styles that use recurring characters, mascots, or illustration elements. Image 1 becomes the visual anchor for the entire series.
+
 **For each image (cover + content + ending)**:
 1. Save prompt to `prompts/NN-{type}-[slug].md` (in user's preferred language)
    - **Backup rule**: If prompt file exists, rename to `prompts/NN-{type}-[slug]-backup-YYYYMMDD-HHMMSS.md`
-2. Generate image using confirmed style and layout
+2. Generate image:
+   - **Image 1**: Generate without `--ref` (this establishes the visual anchor)
+   - **Images 2+**: Generate with `--ref <image-01-path>` for consistency
    - **Backup rule**: If image file exists, rename to `NN-{type}-[slug]-backup-YYYYMMDD-HHMMSS.png`
 3. Report progress after each generation
 
@@ -391,7 +402,7 @@ Reference: `references/config/watermark-guide.md`
 If image generation skill supports `--sessionId`:
 1. Generate unique session ID: `xhs-{topic-slug}-{timestamp}`
 2. Use same session ID for all images
-3. Ensures visual consistency across generated images
+3. Combined with reference image chain, ensures maximum visual consistency
 
 ### Step 6: Completion Report
 

--- a/skills/baoyu-xhs-images/references/workflows/prompt-assembly.md
+++ b/skills/baoyu-xhs-images/references/workflows/prompt-assembly.md
@@ -160,7 +160,21 @@ From outline entry, format:
 If preferences include watermark:
 - Add watermark section with content, position, opacity
 
-### Step 5: Combine
+### Step 5: Visual Consistency — Reference Image Chain
+
+When generating multiple images in a series:
+
+1. **Image 1 (cover)**: Generate without `--ref` — this establishes the visual anchor
+2. **Images 2+**: Always pass image 1 as `--ref` to the image generation skill:
+   ```bash
+   npx -y bun ${SKILL_DIR}/scripts/main.ts \
+     --promptfiles prompts/02-content-xxx.md \
+     --ref path/to/01-cover-xxx.png \
+     --image 02-content-xxx.png --ar 3:4 --quality 2k
+   ```
+   This ensures the AI maintains the same character design, illustration style, and color rendering across the series.
+
+### Step 6: Combine
 
 Assemble all sections into final prompt following base structure.
 


### PR DESCRIPTION
## Summary
- When generating multi-image series (carousels), use image 1 as `--ref` for all subsequent images
- This anchors character design, color rendering, and illustration style across the entire series
- Critical for styles with recurring characters, mascots, or illustration elements

## Problem
AI image generation produces inconsistent characters across slides in a carousel — different hair, face shape, clothing, proportions each time. This breaks the visual cohesion of the series.

## Solution
Simple pattern: generate image 1 first (no `--ref`), then pass it as `--ref` to every subsequent generation. Tested with Google Gemini multimodal — character consistency improved significantly across 8-slide carousels.

## Changes
- `skills/baoyu-xhs-images/SKILL.md` — Added "Reference Image Chain" section in Step 5
- `skills/baoyu-xhs-images/references/workflows/prompt-assembly.md` — Added Step 5 with `--ref` command pattern

## Test plan
- [x] Generated 8-slide carousel without `--ref` — character inconsistent across slides
- [x] Generated same 8-slide carousel with slide 1 as `--ref` — character consistent (same hair, face, clothing)
- [x] Verified `--ref` flag works with `baoyu-image-gen` Google multimodal provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)