### PR TITLE
fix(wechat-browser): fix upload progress check crashing on second iteration

### DIFF
--- a/skills/baoyu-post-to-wechat/scripts/wechat-browser.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-browser.ts
@@ -570,10 +570,7 @@ export async function postToWeChat(options: WeChatBrowserOptions): Promise<void>
     for (let i = 0; i < 30; i++) {
       await sleep(2000);
       const uploadCheck = await cdp.send<{ result: { value: string } }>('Runtime.evaluate', {
-        expression: `
-          const thumbs = document.querySelectorAll('.weui-desktop-upload__thumb, .pic_item, [class*=upload_thumb]');
-          JSON.stringify({ uploaded: thumbs.length });
-        `,
+        expression: `JSON.stringify({ uploaded: document.querySelectorAll('.weui-desktop-upload__thumb, .pic_item, [class*=upload_thumb]').length })`,
         returnByValue: true,
       }, { sessionId });
       const status = JSON.parse(uploadCheck.result.value);


### PR DESCRIPTION
## Problem

When posting image-text (贴图) to WeChat with multiple images, the upload progress check crashes on the second loop iteration with:

```
JSON Parse error: Unexpected identifier "undefined"
```

Upload progress shows `0/N` once and then the script errors out before images are actually uploaded.

## Root Cause

`Runtime.evaluate` reuses the **same JavaScript execution context** across multiple calls within a session. The previous expression used a `const` declaration:

```javascript
const thumbs = document.querySelectorAll('.weui-desktop-upload__thumb, .pic_item, [class*=upload_thumb]');
JSON.stringify({ uploaded: thumbs.length });
```

On the **second iteration**, Chrome throws `SyntaxError: Identifier 'thumbs' has already been declared`, which causes:
- `result.value` to be `undefined` (exception path, no value returned)
- `JSON.parse(undefined)` → `JSON Parse error: Unexpected identifier "undefined"`

## Fix

Inline the selector into a single expression with no variable declaration:

```javascript
JSON.stringify({ uploaded: document.querySelectorAll('...').length })
```

This eliminates the re-declaration error entirely.

## Test

Verified locally: image upload progress loop now correctly polls across all 30 iterations without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)