### PR TITLE
feat(baoyu-image-gen): support OpenAI chat completions endpoint for i…

### DIFF
--- a/skills/baoyu-image-gen/scripts/main.ts
+++ b/skills/baoyu-image-gen/scripts/main.ts
@@ -36,6 +36,7 @@ Environment variables:
   DASHSCOPE_IMAGE_MODEL     Default DashScope model (z-image-turbo)
   REPLICATE_IMAGE_MODEL     Default Replicate model (google/nano-banana-pro)
   OPENAI_BASE_URL           Custom OpenAI endpoint
+  OPENAI_IMAGE_USE_CHAT     Use /chat/completions instead of /images/generations (true|false)
   GOOGLE_BASE_URL           Custom Google endpoint
   DASHSCOPE_BASE_URL        Custom DashScope endpoint
   REPLICATE_BASE_URL        Custom Replicate endpoint


### PR DESCRIPTION
…mage generation

Add OPENAI_IMAGE_USE_CHAT env var (true|false) to route image generation through /chat/completions instead of /images/generations. Extracts base64 image data URLs from the chat response, enabling compatibility with OpenAI-compatible providers that return images via chat API.