### PR TITLE
fix: 正文图片上传使用 media/uploadimg 接口

### DIFF
--- a/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
@@ -75,7 +75,7 @@ async function fetchAccessToken(appId: string, appSecret: string): Promise<strin
 
 // media/uploadimg 接口的限制：只支持 JPG/PNG 格式，文件大小需小于 1MB
 const BODY_IMG_MAX_SIZE = 1024 * 1024; // 1MB
-const BODY_IMG_SUPPORTED_FORMATS = [".jpg", ".jpeg", ".png"];
+const BODY_IMG_UNSUPPORTED_FORMATS = [".gif", ".webp", ".bmp", ".tiff", ".tif", ".svg", ".ico"];
 
 async function uploadImage(
   imagePath: string,
@@ -130,13 +130,63 @@ async function uploadImage(
     contentType = mimeTypes[fileExt] || "image/jpeg";
   }
 
-  // media/uploadimg 接口只支持 JPG/PNG 且小于 1MB，如果是其他格式或文件过大，需要使用 material 接口
-  const isGifOrLarge = fileExt === ".gif" || fileSize > BODY_IMG_MAX_SIZE;
-  if (uploadType === "body" && isGifOrLarge) {
-    console.error(`[wechat-api] Image ${filename} is GIF or larger than 1MB, using material API instead`);
-    uploadType = "material";
+  // 检查是否需要回退到 material 接口
+  const isUnsupportedFormat = BODY_IMG_UNSUPPORTED_FORMATS.includes(fileExt);
+  const isTooLarge = fileSize > BODY_IMG_MAX_SIZE;
+  const needFallback = uploadType === "body" && (isUnsupportedFormat || isTooLarge);
+
+  // 记录警告信息
+  if (needFallback) {
+    const reason = isUnsupportedFormat ? `unsupported format (${fileExt})` : `too large (${(fileSize / 1024 / 1024).toFixed(2)}MB)`;
+    console.error(`[wechat-api] Image ${filename} is ${reason}, using material API for both URL and media_id`);
   }
 
+  // 如果需要回退到 material 接口，为了获取正文图片 URL，需要同时调用两个接口
+  let bodyUrl = "";
+  if (needFallback) {
+    // 先调用 material 接口获取 media_id（也返回 url）
+    const materialResult = await uploadToWechat(fileBuffer, filename, contentType, accessToken, "material");
+    // 再调用 body 接口获取可以在正文中使用的 URL
+    const bodyResult = await uploadToWechat(fileBuffer, filename, contentType, accessToken, "body");
+    bodyUrl = bodyResult.url || materialResult.url;
+
+    if (materialResult.url?.startsWith("http://")) {
+      materialResult.url = materialResult.url.replace(/^http:\/\//i, "https://");
+    }
+    return {
+      url: bodyUrl,
+      media_id: materialResult.media_id,
+    } as UploadResponse;
+  }
+
+  // 正常情况：直接使用选定的接口上传
+  const result = await uploadToWechat(fileBuffer, filename, contentType, accessToken, uploadType);
+
+  // media/uploadimg 接口只返回 URL，material/add_material 返回 media_id
+  if (uploadType === "body") {
+    if (result.url?.startsWith("http://")) {
+      result.url = result.url.replace(/^http:\/\//i, "https://");
+    }
+    return {
+      url: result.url,
+      media_id: "",
+    } as UploadResponse;
+  } else {
+    if (result.url?.startsWith("http://")) {
+      result.url = result.url.replace(/^http:\/\//i, "https://");
+    }
+    return result;
+  }
+}
+
+// 实际的微信上传函数
+async function uploadToWechat(
+  fileBuffer: Buffer,
+  filename: string,
+  contentType: string,
+  accessToken: string,
+  uploadType: "body" | "material"
+): Promise<UploadResponse> {
   const boundary = `----WebKitFormBoundary${Date.now().toString(16)}`;
   const header = [
     `--${boundary}`,
@@ -151,7 +201,6 @@ async function uploadImage(
   const footerBuffer = Buffer.from(footer, "utf-8");
   const body = Buffer.concat([headerBuffer, fileBuffer, footerBuffer]);
 
-  // 根据上传类型选择不同的接口
   const uploadUrl = uploadType === "body" ? UPLOAD_BODY_IMG_URL : UPLOAD_MATERIAL_URL;
   const url = `${uploadUrl}?type=image&access_token=${accessToken}`;
   const res = await fetch(url, {
@@ -167,23 +216,7 @@ async function uploadImage(
     throw new Error(`Upload failed ${data.errcode}: ${data.errmsg}`);
   }
 
-  // media/uploadimg 接口只返回 URL，material/add_material 返回 media_id
-  if (uploadType === "body") {
-    // 正文图片上传，返回 URL
-    if (data.url?.startsWith("http://")) {
-      data.url = data.url.replace(/^http:\/\//i, "https://");
-    }
-    return {
-      url: data.url,
-      media_id: "",
-    } as UploadResponse;
-  } else {
-    // 封面图片上传，返回 media_id
-    if (data.url?.startsWith("http://")) {
-      data.url = data.url.replace(/^http:\/\//i, "https://");
-    }
-    return data;
-  }
+  return data;
 }
 
 async function uploadImagesInHtml(


### PR DESCRIPTION
# Fix: 正文图片上传使用 media/uploadimg 接口

## 问题描述

当前 `wechat-api.ts` 使用 `material/add_material` 接口上传所有图片(包括正文图片和封面图片)。根据微信公众号官方文档:

- **正文图片**必须使用 `media/uploadimg` 接口,返回 URL 格式为 `http://mmbiz.qpic.cn/...?from=appmsg`
- **封面图片**应使用 `material/add_material` 接口,返回 `media_id`(news 类型文章必需)

使用错误的接口会导致正文图片无法在公众号后台正确显示。

## 修复内容

### 1. 新增上传接口常量

```typescript
const TOKEN_URL = "https://api.weixin.qq.com/cgi-bin/token";
const UPLOAD_BODY_IMG_URL = "https://api.weixin.qq.com/cgi-bin/media/uploadimg";
const UPLOAD_MATERIAL_URL = "https://api.weixin.qq.com/cgi-bin/material/add_material";
const DRAFT_URL = "https://api.weixin.qq.com/cgi-bin/draft/add";
```

### 2. 修改 uploadImage 函数

添加 `uploadType` 参数区分两种上传方式:

```typescript
async function uploadImage(
  imagePath: string,
  accessToken: string,
  baseDir?: string,
  uploadType: "body" | "material" = "body"
): Promise<UploadResponse> {
  // ... 省略文件读取逻辑 ...

  // 根据上传类型选择不同的接口
  const uploadUrl = uploadType === "body" ? UPLOAD_BODY_IMG_URL : UPLOAD_MATERIAL_URL;
  const url = `${uploadUrl}?type=image&access_token=${accessToken}`;
  
  // ... 省略上传逻辑 ...

  // media/uploadimg 接口只返回 URL，material/add_material 返回 media_id
  if (uploadType === "body") {
    return {
      url: data.url,
      media_id: "", // 正文图片上传不返回 media_id
    } as UploadResponse;
  } else {
    return {
      url: data.url || "",
      media_id: data.media_id,
    } as UploadResponse;
  }
}
```

### 3. 修改 uploadImagesInHtml 函数

- 重命名返回值 `firstMediaId` 为 `firstImageUrl`,因为正文图片上传返回的是 URL 而非 media_id
- 正文图片上传时调用 `uploadImage(imagePath, accessToken, baseDir, "body")`

### 4. 修改主流程

- 封面图片上传时调用 `uploadImage(coverPath, accessToken, baseDir, "material")`
- 添加更清晰的错误提示,告知用户 news 类型文章需要封面图

## 测试结果

使用修改后的代码发布测试文章,正文图片成功上传并显示:

```
[wechat-api] Uploading body image: /path/to/step1.jpg
[wechat-api] Upload successful, URL: http://mmbiz.qpic.cn/mmbiz_jpg/...?from=appmsg

[wechat-api] Uploading body image: /path/to/step2.jpg
[wechat-api] Upload successful, URL: http://mmbiz.qpic.cn/sz_mmbiz_jpg/...?from=appmsg

[wechat-api] Uploading body image: /path/to/step3.jpg
[wechat-api] Upload successful, URL: http://mmbiz.qpic.cn/mmbiz_png/...?from=appmsg

[wechat-api] Uploading cover: imgs/cover.jpg
[wechat-api] Cover uploaded successfully, media_id: 7rcvhNbY7dJAbivFX4fRfyAFQ7n67dyh3nENqQZi...
```

## 兼容性说明

- 向后兼容:默认使用 `uploadType = "body"`,现有代码无需修改即可使用
- 两种上传方式独立,不会相互影响
- 代码逻辑更清晰,符合微信公众号官方API规范

## 相关文档

- [微信公众号正文图片上传接口](https://developers.weixin.qq.com/doc/offiaccount/Asset_Management/Adding_Permanent_Assets.html)
- [微信公众号新增永久素材接口](https://developers.weixin.qq.com/doc/offiaccount/Asset_Management/Adding_Permanent_Assets.html)