### PR TITLE
fix(baoyu-image-gen): align `OpenRouter` image generation with current API

### DIFF
--- a/skills/baoyu-image-gen/scripts/providers/openrouter.test.ts
+++ b/skills/baoyu-image-gen/scripts/providers/openrouter.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./openrouter.ts";
 
 const GEMINI_MODEL = "google/gemini-3.1-flash-image-preview";
+const GEMINI_25_MODEL = "google/gemini-2.5-flash-image-preview";
 const FLUX_MODEL = "black-forest-labs/flux.2-pro";
 
 function makeArgs(overrides: Partial<CliArgs> = {}): CliArgs {
@@ -78,12 +79,17 @@ test("OpenRouter size and aspect helpers infer expected defaults", () => {
   assert.equal(getAspectRatio(GEMINI_MODEL, makeArgs({ size: "2048x1024" })), null);
   assert.equal(getAspectRatio(GEMINI_MODEL, makeArgs({ size: "1600x900" })), "16:9");
   assert.equal(getAspectRatio(GEMINI_MODEL, makeArgs({ size: "1024x4096" })), "1:4");
+  assert.equal(getAspectRatio(GEMINI_25_MODEL, makeArgs({ size: "1024x4096" })), null);
   assert.equal(getAspectRatio(FLUX_MODEL, makeArgs({ size: "1024x4096" })), null);
 });
 
 test("OpenRouter validates explicit aspect ratios against model support", () => {
   assert.doesNotThrow(() =>
     validateArgs(GEMINI_MODEL, makeArgs({ aspectRatio: "1:4" })),
+  );
+  assert.throws(
+    () => validateArgs(GEMINI_25_MODEL, makeArgs({ aspectRatio: "1:4" })),
+    /does not support aspect ratio 1:4/,
   );
   assert.throws(
     () => validateArgs(FLUX_MODEL, makeArgs({ aspectRatio: "1:4" })),

--- a/skills/baoyu-image-gen/scripts/providers/openrouter.ts
+++ b/skills/baoyu-image-gen/scripts/providers/openrouter.ts
@@ -45,7 +45,7 @@ export function getDefaultModel(): string {
 }
 
 function normalizeModelId(model: string): string {
-  return model.trim().toLowerCase();
+  return model.trim().toLowerCase().split(":")[0]!;
 }
 
 export function isGeminiImageModel(model: string): boolean {
@@ -54,7 +54,8 @@ export function isGeminiImageModel(model: string): boolean {
 }
 
 function getSupportedAspectRatios(model: string): Set<string> {
-  if (!isGeminiImageModel(model)) {
+  const normalized = normalizeModelId(model);
+  if (normalized !== "google/gemini-3.1-flash-image-preview") {
     return new Set(COMMON_ASPECT_RATIOS);
   }
 


### PR DESCRIPTION
## Summary

Fix OpenRouter image generation in `baoyu-image-gen` to match the current OpenRouter API.

## Changes

- switch request payload from `imageGenerationOptions` to `image_config`
- send plain string `content` for text-only image generation
- keep multimodal array `content` when reference images are provided
- include `finish_reason` in no-image errors for easier debugging
- add OpenRouter provider tests for request/response handling

## Why

The previous OpenRouter request format could return `No image in OpenRouter response` for image-capable models such as `google/gemini-3.1-flash-image-preview`.

## Verification

```bash
node --import tsx --test "skills/baoyu-image-gen/scripts/providers/*.test.ts"
```

All provider tests passed locally.