### PR TITLE
feat(youtube-transcript): add end times to chapter data

### DIFF
--- a/skills/baoyu-youtube-transcript/scripts/main.ts
+++ b/skills/baoyu-youtube-transcript/scripts/main.ts
@@ -263,7 +263,7 @@ function parseChapters(description: string, duration: number = 0): Chapter[] {
   return raw.map((ch, i) => ({
     title: ch.title,
     start: ch.start,
-    end: i < raw.length - 1 ? raw[i + 1].start : duration,
+    end: i < raw.length - 1 ? raw[i + 1].start : Math.max(duration, ch.start),
   }));
 }
 
@@ -700,13 +700,13 @@ async function processVideo(videoId: string, opts: Options): Promise<VideoResult
     const wantLangs = opts.translate ? [opts.translate] : opts.languages;
     if (!wantLangs.includes(meta.language.code)) needsFetch = true;
     // Backfill chapter end times for caches created before this field existed
-    if (meta.chapters.length > 0 && meta.chapters[0].end === undefined) {
+    if (!needsFetch && meta.chapters.length > 0 && meta.chapters.some((ch: any) => ch.end === undefined)) {
       for (let i = 0; i < meta.chapters.length; i++) {
-        (meta.chapters[i] as any).end = i < meta.chapters.length - 1
+        meta.chapters[i].end = i < meta.chapters.length - 1
           ? meta.chapters[i + 1].start
-          : meta.duration;
+          : Math.max(meta.duration, meta.chapters[i].start);
       }
-      writeFileSync(join(videoDir, "meta.json"), JSON.stringify(meta, null, 2));
+      try { writeFileSync(join(videoDir, "meta.json"), JSON.stringify(meta, null, 2)); } catch {}
     }
   }
 


### PR DESCRIPTION
## What

Adds an `end` field to the `Chapter` interface and `parseChapters` output.

**Before:**
```json
{"title": "Overview", "start": 0}
{"title": "What is Claude Code?", "start": 21}
```

**After:**
```json
{"title": "Overview", "start": 0, "end": 21}
{"title": "What is Claude Code?", "start": 21, "end": 70}
```

## Why

Chapter data currently only includes `start`, requiring downstream consumers to compute `end` themselves from adjacent chapters. Since `parseChapters` already has all the information needed (chapter list + video duration), it makes sense to provide complete time ranges.

This is useful for any tool that needs chapter boundaries — video clipping (ffmpeg `-ss`/`-to`), progress bars, segment analytics, etc.

## How

- Each chapter's `end` = next chapter's `start`
- Last chapter's `end` = video total duration (from `videoDetails.lengthSeconds`)
- `parseChapters` now accepts an optional `duration` parameter

## Testing

Tested with `ntDIxaeo3Wg` (Tech With Tim — Claude Code Full Tutorial, 35min, 15 chapters). All chapters have correct start/end times, last chapter ends at video duration (2148s).

1 file changed, 12 insertions, 5 deletions. No breaking changes — `end` is a new additive field.