### PR TITLE
Add schema-aware Replicate support for Seedream and Wan image modelsFeature/improve replicate provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ AI SDK-based image generation using OpenAI, Azure OpenAI, Google, OpenRouter, Da
 | `GOOGLE_IMAGE_MODEL` | Google model | `gemini-3-pro-image-preview` |
 | `DASHSCOPE_IMAGE_MODEL` | DashScope model | `qwen-image-2.0-pro` |
 | `MINIMAX_IMAGE_MODEL` | MiniMax model | `image-01` |
-| `REPLICATE_IMAGE_MODEL` | Replicate model | `google/nano-banana-pro` |
+| `REPLICATE_IMAGE_MODEL` | Replicate model | `google/nano-banana-2` |
 | `JIMENG_IMAGE_MODEL` | Jimeng model | `jimeng_t2i_v40` |
 | `SEEDREAM_IMAGE_MODEL` | Seedream model | `doubao-seedream-5-0-260128` |
 | `OPENAI_BASE_URL` | Custom OpenAI endpoint | - |
@@ -1108,7 +1108,7 @@ MINIMAX_IMAGE_MODEL=image-01
 
 # Replicate
 REPLICATE_API_TOKEN=r8_xxx
-REPLICATE_IMAGE_MODEL=google/nano-banana-pro
+REPLICATE_IMAGE_MODEL=google/nano-banana-2
 # REPLICATE_BASE_URL=https://api.replicate.com
 
 # Jimeng (即梦)

--- a/README.zh.md
+++ b/README.zh.md
@@ -768,7 +768,7 @@ AI 驱动的生成后端。
 | `GOOGLE_IMAGE_MODEL` | Google 模型 | `gemini-3-pro-image-preview` |
 | `DASHSCOPE_IMAGE_MODEL` | DashScope 模型 | `qwen-image-2.0-pro` |
 | `MINIMAX_IMAGE_MODEL` | MiniMax 模型 | `image-01` |
-| `REPLICATE_IMAGE_MODEL` | Replicate 模型 | `google/nano-banana-pro` |
+| `REPLICATE_IMAGE_MODEL` | Replicate 模型 | `google/nano-banana-2` |
 | `JIMENG_IMAGE_MODEL` | 即梦模型 | `jimeng_t2i_v40` |
 | `SEEDREAM_IMAGE_MODEL` | 豆包模型 | `doubao-seedream-5-0-260128` |
 | `OPENAI_BASE_URL` | 自定义 OpenAI 端点 | - |
@@ -1108,7 +1108,7 @@ MINIMAX_IMAGE_MODEL=image-01
 
 # Replicate
 REPLICATE_API_TOKEN=r8_xxx
-REPLICATE_IMAGE_MODEL=google/nano-banana-pro
+REPLICATE_IMAGE_MODEL=google/nano-banana-2
 # REPLICATE_BASE_URL=https://api.replicate.com
 
 # 即梦（Jimeng）

--- a/skills/baoyu-imagine/SKILL.md
+++ b/skills/baoyu-imagine/SKILL.md
@@ -112,7 +112,7 @@ ${BUN_X} {baseDir}/scripts/main.ts --prompt "A girl stands by the library window
 # MiniMax with custom size (documented for image-01)
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cinematic poster" --image out.jpg --provider minimax --model image-01 --size 1536x1024
 
-# Replicate (google/nano-banana-pro)
+# Replicate (google/nano-banana-2)
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider replicate
 
 # Replicate with specific model
@@ -136,7 +136,7 @@ ${BUN_X} {baseDir}/scripts/main.ts --batchfile batch.json --jobs 4 --json
       "promptFiles": ["prompts/hero.md"],
       "image": "out/hero.png",
       "provider": "replicate",
-      "model": "google/nano-banana-pro",
+      "model": "google/nano-banana-2",
       "ar": "16:9",
       "quality": "2k"
     },
@@ -192,7 +192,7 @@ Paths in `promptFiles`, `image`, and `ref` are resolved relative to the batch fi
 | `GOOGLE_IMAGE_MODEL` | Google model override |
 | `DASHSCOPE_IMAGE_MODEL` | DashScope model override (default: `qwen-image-2.0-pro`) |
 | `MINIMAX_IMAGE_MODEL` | MiniMax model override (default: `image-01`) |
-| `REPLICATE_IMAGE_MODEL` | Replicate model override (default: google/nano-banana-pro) |
+| `REPLICATE_IMAGE_MODEL` | Replicate model override (default: google/nano-banana-2) |
 | `JIMENG_IMAGE_MODEL` | Jimeng model override (default: jimeng_t2i_v40) |
 | `SEEDREAM_IMAGE_MODEL` | Seedream model override (default: doubao-seedream-5-0-260128) |
 | `OPENAI_BASE_URL` | Custom OpenAI endpoint |
@@ -324,7 +324,7 @@ Notes:
 
 Supported model formats:
 
-- `owner/name` (recommended for official models), e.g. `google/nano-banana-pro`
+- `owner/name` (recommended for official models), e.g. `google/nano-banana-2`
 - `owner/name:version` (community models by version), e.g. `stability-ai/sdxl:<version>`
 
 Examples:

--- a/skills/baoyu-imagine/references/config/first-time-setup.md
+++ b/skills/baoyu-imagine/references/config/first-time-setup.md
@@ -56,7 +56,7 @@ options:
   - label: "MiniMax"
     description: "MiniMax image generation with subject-reference character workflows"
   - label: "Replicate"
-    description: "Community models - nano-banana-pro, flexible model selection"
+    description: "Community models - nano-banana-2, flexible model selection"
 ```
 
 ### Question 2: Default Google Model
@@ -263,7 +263,7 @@ Notes for DashScope setup:
 header: "Replicate Model"
 question: "Choose a default Replicate image generation model?"
 options:
-  - label: "google/nano-banana-pro (Recommended)"
+  - label: "google/nano-banana-2 (Recommended)"
     description: "Google's fast image model on Replicate"
   - label: "google/nano-banana"
     description: "Google's base image model on Replicate"

--- a/skills/baoyu-imagine/references/config/preferences-schema.md
+++ b/skills/baoyu-imagine/references/config/preferences-schema.md
@@ -26,7 +26,7 @@ default_model:
   openrouter: null          # e.g., "google/gemini-3.1-flash-image-preview"
   dashscope: null           # e.g., "qwen-image-2.0-pro"
   minimax: null             # e.g., "image-01"
-  replicate: null           # e.g., "google/nano-banana-pro"
+  replicate: null           # e.g., "google/nano-banana-2"
 
 batch:
   max_workers: 10
@@ -101,7 +101,7 @@ default_model:
   openrouter: "google/gemini-3.1-flash-image-preview"
   dashscope: "qwen-image-2.0-pro"
   minimax: "image-01"
-  replicate: "google/nano-banana-pro"
+  replicate: "google/nano-banana-2"
 batch:
   max_workers: 10
   provider_limits:

--- a/skills/baoyu-imagine/scripts/main.ts
+++ b/skills/baoyu-imagine/scripts/main.ts
@@ -96,7 +96,7 @@ Batch file format:
         "promptFiles": ["prompts/hero.md"],
         "image": "out/hero.png",
         "provider": "replicate",
-        "model": "google/nano-banana-pro",
+        "model": "google/nano-banana-2",
         "ar": "16:9"
       }
     ]
@@ -123,7 +123,7 @@ Environment variables:
   GOOGLE_IMAGE_MODEL        Default Google model (gemini-3-pro-image-preview)
   DASHSCOPE_IMAGE_MODEL     Default DashScope model (qwen-image-2.0-pro)
   MINIMAX_IMAGE_MODEL       Default MiniMax model (image-01)
-  REPLICATE_IMAGE_MODEL     Default Replicate model (google/nano-banana-pro)
+  REPLICATE_IMAGE_MODEL     Default Replicate model (google/nano-banana-2)
   JIMENG_IMAGE_MODEL        Default Jimeng model (jimeng_t2i_v40)
   SEEDREAM_IMAGE_MODEL      Default Seedream model (doubao-seedream-5-0-260128)
   OPENAI_BASE_URL           Custom OpenAI endpoint

--- a/skills/baoyu-imagine/scripts/providers/replicate.test.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.test.ts
@@ -111,7 +111,7 @@ test("Replicate input builder maps Seedream models to size-based schema", () => 
       "A robot painter",
       "bytedance/seedream-4.5",
       makeArgs({
-        quality: "2k",
+        size: "1536x1024",
         aspectRatio: "16:9",
         n: 4,
       }),
@@ -119,8 +119,9 @@ test("Replicate input builder maps Seedream models to size-based schema", () => 
     ),
     {
       prompt: "A robot painter",
-      size: "2K",
-      aspect_ratio: "16:9",
+      size: "custom",
+      width: 1536,
+      height: 1024,
       sequential_image_generation: "auto",
       max_images: 4,
       image_input: ["data:image/png;base64,AAAA"],
@@ -207,12 +208,16 @@ test("Replicate input builder falls back to nano-banana schema for unknown model
 test("Replicate validation catches unsupported Seedream and Wan argument combinations", () => {
   assert.throws(
     () => validateArgs("bytedance/seedream-4.5", makeArgs({ size: "large" })),
-    /Seedream on Replicate requires --size/,
+    /Seedream 4.5 on Replicate requires --size/,
   );
 
   assert.throws(
     () => validateArgs("bytedance/seedream-5-lite", makeArgs({ size: "4K" })),
     /Seedream on Replicate requires --size to be one of 2K, 3K/,
+  );
+
+  assert.doesNotThrow(
+    () => validateArgs("bytedance/seedream-4.5", makeArgs({ size: "1536x1024" })),
   );
 
   assert.throws(

--- a/skills/baoyu-imagine/scripts/providers/replicate.test.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.test.ts
@@ -182,6 +182,22 @@ test("Replicate input builder maps Wan models to their native schema", () => {
       thinking_mode: true,
     },
   );
+
+  assert.deepEqual(
+    buildInput(
+      "A robot painter",
+      "wan-video/wan-2.7-image",
+      makeArgs({
+        size: "1536x1024",
+      }),
+      [],
+    ),
+    {
+      prompt: "A robot painter",
+      size: "1536*1024",
+      thinking_mode: true,
+    },
+  );
 });
 
 test("Replicate input builder falls back to nano-banana schema for unknown models", () => {
@@ -245,9 +261,22 @@ test("Replicate validation catches unsupported Seedream and Wan argument combina
     /Wan image models on Replicate require --size/,
   );
 
+  assert.doesNotThrow(
+    () => validateArgs("wan-video/wan-2.7-image", makeArgs({ size: "1536x1024" })),
+  );
+
+  assert.doesNotThrow(
+    () => validateArgs("wan-video/wan-2.7-image-pro", makeArgs({ size: "1920x1080" })),
+  );
+
+  assert.throws(
+    () => validateArgs("wan-video/wan-2.7-image-pro", makeArgs({ referenceImages: Array.from({ length: 10 }, () => "ref.png") })),
+    /support at most 9 reference images/,
+  );
+
   assert.throws(
     () => validateArgs("wan-video/wan-2.7-image", makeArgs({ size: "4K" })),
-    /Wan image models on Replicate require --size to be one of/,
+    /Wan image models on Replicate require --size to be one of 1K, 2K or custom dimensions/,
   );
 
   assert.throws(

--- a/skills/baoyu-imagine/scripts/providers/replicate.test.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.test.ts
@@ -162,6 +162,7 @@ test("Replicate input builder maps Wan models to their native schema", () => {
       size: "2K",
       num_outputs: 2,
       images: ["data:image/png;base64,AAAA"],
+      thinking_mode: false,
     },
   );
 
@@ -212,6 +213,16 @@ test("Replicate validation catches unsupported Seedream and Wan argument combina
   assert.throws(
     () => validateArgs("bytedance/seedream-5-lite", makeArgs({ size: "4K" })),
     /Seedream on Replicate requires --size to be one of 2K, 3K/,
+  );
+
+  assert.throws(
+    () => validateArgs("bytedance/seedream-4.5", makeArgs({ referenceImages: Array.from({ length: 15 }, () => "ref.png") })),
+    /supports at most 14 reference images/,
+  );
+
+  assert.throws(
+    () => validateArgs("bytedance/seedream-5-lite", makeArgs({ referenceImages: Array.from({ length: 10 }, () => "ref.png"), n: 10 })),
+    /allows at most 15 total images per request/,
   );
 
   assert.throws(

--- a/skills/baoyu-imagine/scripts/providers/replicate.test.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.test.ts
@@ -82,6 +82,29 @@ test("Replicate input builder keeps nano-banana mapping for compatible models", 
   );
 });
 
+test("Replicate fallback preserves --n for unknown models", () => {
+  assert.deepEqual(
+    buildInput(
+      "A robot painter",
+      "unknown-owner/unknown-model",
+      makeArgs({
+        aspectRatio: "16:9",
+        quality: "2k",
+        n: 4,
+      }),
+      ["ref"],
+    ),
+    {
+      prompt: "A robot painter",
+      aspect_ratio: "16:9",
+      resolution: "2K",
+      number_of_images: 4,
+      output_format: "png",
+      image_input: ["ref"],
+    },
+  );
+});
+
 test("Replicate input builder maps Seedream models to size-based schema", () => {
   assert.deepEqual(
     buildInput(

--- a/skills/baoyu-imagine/scripts/providers/replicate.test.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.test.ts
@@ -5,7 +5,9 @@ import type { CliArgs } from "../types.ts";
 import {
   buildInput,
   extractOutputUrl,
+  generateImage,
   parseModelId,
+  validateArgs,
 } from "./replicate.ts";
 
 function makeArgs(overrides: Partial<CliArgs> = {}): CliArgs {
@@ -47,21 +49,20 @@ test("Replicate model parsing accepts official formats and rejects malformed one
   );
 });
 
-test("Replicate input builder maps aspect ratio, image count, quality, and refs", () => {
+test("Replicate input builder keeps nano-banana mapping for compatible models", () => {
   assert.deepEqual(
     buildInput(
       "A robot painter",
+      "google/nano-banana-2",
       makeArgs({
         aspectRatio: "16:9",
         quality: "2k",
-        n: 3,
       }),
       ["data:image/png;base64,AAAA"],
     ),
     {
       prompt: "A robot painter",
       aspect_ratio: "16:9",
-      number_of_images: 3,
       resolution: "2K",
       output_format: "png",
       image_input: ["data:image/png;base64,AAAA"],
@@ -69,7 +70,7 @@ test("Replicate input builder maps aspect ratio, image count, quality, and refs"
   );
 
   assert.deepEqual(
-    buildInput("A robot painter", makeArgs({ quality: "normal" }), ["ref"]),
+    buildInput("A robot painter", "google/nano-banana-pro", makeArgs({ quality: "normal" }), ["ref"]),
     {
       prompt: "A robot painter",
       aspect_ratio: "match_input_image",
@@ -77,6 +78,146 @@ test("Replicate input builder maps aspect ratio, image count, quality, and refs"
       output_format: "png",
       image_input: ["ref"],
     },
+  );
+});
+
+test("Replicate input builder maps Seedream models to size-based schema", () => {
+  assert.deepEqual(
+    buildInput(
+      "A robot painter",
+      "bytedance/seedream-4.5",
+      makeArgs({
+        quality: "2k",
+        aspectRatio: "16:9",
+        n: 4,
+      }),
+      ["data:image/png;base64,AAAA"],
+    ),
+    {
+      prompt: "A robot painter",
+      size: "2K",
+      aspect_ratio: "16:9",
+      sequential_image_generation: "auto",
+      max_images: 4,
+      image_input: ["data:image/png;base64,AAAA"],
+    },
+  );
+
+  assert.deepEqual(
+    buildInput(
+      "A robot painter",
+      "bytedance/seedream-5-lite",
+      makeArgs({
+        size: "3K",
+        aspectRatio: "4:3",
+      }),
+      [],
+    ),
+    {
+      prompt: "A robot painter",
+      size: "3K",
+      aspect_ratio: "4:3",
+      output_format: "png",
+    },
+  );
+});
+
+test("Replicate input builder maps Wan models to their native schema", () => {
+  assert.deepEqual(
+    buildInput(
+      "A robot painter",
+      "wan-video/wan-2.7-image-pro",
+      makeArgs({
+        quality: "2k",
+        n: 2,
+      }),
+      ["data:image/png;base64,AAAA"],
+    ),
+    {
+      prompt: "A robot painter",
+      size: "2K",
+      num_outputs: 2,
+      images: ["data:image/png;base64,AAAA"],
+    },
+  );
+
+  assert.deepEqual(
+    buildInput(
+      "A robot painter",
+      "wan-video/wan-2.7-image",
+      makeArgs({
+        size: "2048x1152",
+      }),
+      [],
+    ),
+    {
+      prompt: "A robot painter",
+      size: "2048*1152",
+      thinking_mode: true,
+    },
+  );
+});
+
+test("Replicate input builder falls back to nano-banana schema for unknown models", () => {
+  assert.deepEqual(
+    buildInput(
+      "A robot painter",
+      "unknown-owner/unknown-model",
+      makeArgs({
+        aspectRatio: "16:9",
+        quality: "2k",
+      }),
+      ["ref"],
+    ),
+    {
+      prompt: "A robot painter",
+      aspect_ratio: "16:9",
+      resolution: "2K",
+      output_format: "png",
+      image_input: ["ref"],
+    },
+  );
+});
+
+test("Replicate validation catches unsupported Seedream and Wan argument combinations", () => {
+  assert.throws(
+    () => validateArgs("bytedance/seedream-4.5", makeArgs({ size: "large" })),
+    /Seedream on Replicate requires --size/,
+  );
+
+  assert.throws(
+    () => validateArgs("bytedance/seedream-5-lite", makeArgs({ size: "4K" })),
+    /Seedream on Replicate requires --size to be one of 2K, 3K/,
+  );
+
+  assert.throws(
+    () => validateArgs("google/nano-banana-2", makeArgs({ n: 2 })),
+    /Nano Banana models on Replicate do not support --n yet/,
+  );
+
+  assert.throws(
+    () => validateArgs("wan-video/wan-2.7-image-pro", makeArgs({ aspectRatio: "16:9" })),
+    /Wan image models on Replicate require --size when using --ar/,
+  );
+
+  assert.throws(
+    () => validateArgs("wan-video/wan-2.7-image", makeArgs({ size: "wide" })),
+    /Wan image models on Replicate require --size/,
+  );
+
+  assert.throws(
+    () => validateArgs("wan-video/wan-2.7-image", makeArgs({ size: "4K" })),
+    /Wan image models on Replicate require --size to be one of/,
+  );
+
+  assert.throws(
+    () => validateArgs("wan-video/wan-2.7-image-pro", makeArgs({ size: "4K", referenceImages: ["ref"] })),
+    /only supports 4K for text-to-image requests without input images/,
+  );
+
+  assert.throws(
+    () => validateArgs("wan-video/wan-2.7-image-pro", makeArgs({ n: 5 })),
+    /support --n values from 1 to 4/,
   );
 });
 
@@ -98,4 +239,26 @@ test("Replicate output extraction supports string, array, and object URLs", () =
     () => extractOutputUrl({ output: { invalid: true } } as never),
     /Unexpected Replicate output format/,
   );
+});
+
+test("Replicate generateImage validates arguments before making API requests", async () => {
+  const previousToken = process.env.REPLICATE_API_TOKEN;
+  process.env.REPLICATE_API_TOKEN = "test-token";
+
+  try {
+    await assert.rejects(
+      generateImage(
+        "A robot painter",
+        "wan-video/wan-2.7-image-pro",
+        makeArgs({ aspectRatio: "16:9" }),
+      ),
+      /Wan image models on Replicate require --size when using --ar/,
+    );
+  } finally {
+    if (previousToken === undefined) {
+      delete process.env.REPLICATE_API_TOKEN;
+    } else {
+      process.env.REPLICATE_API_TOKEN = previousToken;
+    }
+  }
 });

--- a/skills/baoyu-imagine/scripts/providers/replicate.test.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.test.ts
@@ -6,6 +6,7 @@ import {
   buildInput,
   extractOutputUrl,
   generateImage,
+  getDefaultOutputExtension,
   parseModelId,
   validateArgs,
 } from "./replicate.ts";
@@ -239,6 +240,12 @@ test("Replicate output extraction supports string, array, and object URLs", () =
     () => extractOutputUrl({ output: { invalid: true } } as never),
     /Unexpected Replicate output format/,
   );
+});
+
+test("Replicate default output extension matches model family behavior", () => {
+  assert.equal(getDefaultOutputExtension("bytedance/seedream-4.5"), ".jpg");
+  assert.equal(getDefaultOutputExtension("bytedance/seedream-5-lite"), ".png");
+  assert.equal(getDefaultOutputExtension("google/nano-banana-2"), ".png");
 });
 
 test("Replicate generateImage validates arguments before making API requests", async () => {

--- a/skills/baoyu-imagine/scripts/providers/replicate.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.ts
@@ -138,6 +138,10 @@ function buildNanoBananaInput(prompt: string, args: CliArgs, referenceImages: st
     input.resolution = "2K";
   }
 
+  if (args.n > 1) {
+    input.number_of_images = args.n;
+  }
+
   input.output_format = "png";
 
   if (referenceImages.length > 0) {

--- a/skills/baoyu-imagine/scripts/providers/replicate.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.ts
@@ -156,10 +156,21 @@ function buildSeedreamInput(prompt: string, model: string, args: CliArgs, refere
   const requestedSize = args.size || getSeedreamDefaultSize(model, args.quality);
 
   if (requestedSize) {
-    input.size = normalizePresetSize(requestedSize);
+    if (isSeedream45Model(model)) {
+      const parsed = parsePixelSize(requestedSize);
+      if (parsed) {
+        input.size = "custom";
+        input.width = parsed.width;
+        input.height = parsed.height;
+      } else {
+        input.size = normalizePresetSize(requestedSize);
+      }
+    } else {
+      input.size = normalizePresetSize(requestedSize);
+    }
   }
 
-  if (args.aspectRatio) {
+  if (args.aspectRatio && input.size !== "custom") {
     input.aspect_ratio = args.aspectRatio;
   }
 
@@ -217,11 +228,20 @@ export function validateArgs(model: string, args: CliArgs): void {
     const referenceCount = args.referenceImages.length;
 
     if (args.size) {
-      const normalizedSize = normalizePresetSize(args.size);
-      if (!getAllowedSeedreamSizes(model).has(normalizedSize)) {
-        throw new Error(
-          `Seedream on Replicate requires --size to be one of ${Array.from(getAllowedSeedreamSizes(model)).join(", ")}. Received: ${args.size}`
-        );
+      if (isSeedream45Model(model)) {
+        const normalizedSize = normalizePresetSize(args.size);
+        if (!getAllowedSeedreamSizes(model).has(normalizedSize) && !parsePixelSize(args.size)) {
+          throw new Error(
+            `Seedream 4.5 on Replicate requires --size to be one of ${Array.from(getAllowedSeedreamSizes(model)).join(", ")} or custom dimensions like 1536x1024. Received: ${args.size}`
+          );
+        }
+      } else {
+        const normalizedSize = normalizePresetSize(args.size);
+        if (!getAllowedSeedreamSizes(model).has(normalizedSize)) {
+          throw new Error(
+            `Seedream on Replicate requires --size to be one of ${Array.from(getAllowedSeedreamSizes(model)).join(", ")}. Received: ${args.size}`
+          );
+        }
       }
     }
 

--- a/skills/baoyu-imagine/scripts/providers/replicate.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.ts
@@ -9,24 +9,8 @@ const MAX_POLL_MS = 300_000;
 const SIZE_PRESET_PATTERN = /^\d+K$/i;
 const SEEDREAM_45_SIZES = new Set(["2K", "4K"]);
 const SEEDREAM_5_LITE_SIZES = new Set(["2K", "3K"]);
-const WAN_PRO_SIZES = new Set([
-  "1K", "2K", "4K",
-  "1024*1024", "2048*2048", "4096*4096",
-  "1280*720", "720*1280",
-  "2048*1152", "1152*2048",
-  "4096*2304", "2304*4096",
-  "1024*768", "768*1024",
-  "2048*1536", "1536*2048",
-  "4096*3072", "3072*4096",
-]);
-const WAN_SIZES = new Set([
-  "1K", "2K",
-  "1024*1024", "2048*2048",
-  "1280*720", "720*1280",
-  "2048*1152", "1152*2048",
-  "1024*768", "768*1024",
-  "2048*1536", "1536*2048",
-]);
+const WAN_PRO_PRESET_SIZES = new Set(["1K", "2K", "4K"]);
+const WAN_PRESET_SIZES = new Set(["1K", "2K"]);
 
 export function getDefaultModel(): string {
   return process.env.REPLICATE_IMAGE_MODEL || DEFAULT_MODEL;
@@ -116,7 +100,7 @@ function getAllowedSeedreamSizes(model: string): Set<string> {
 }
 
 function getAllowedWanSizes(model: string): Set<string> {
-  return isWanProModel(model) ? WAN_PRO_SIZES : WAN_SIZES;
+  return isWanProModel(model) ? WAN_PRO_PRESET_SIZES : WAN_PRESET_SIZES;
 }
 
 function normalizePresetSize(size: string): string {
@@ -265,11 +249,15 @@ export function validateArgs(model: string, args: CliArgs): void {
       throw new Error("Wan image models on Replicate require --size when using --ar. This provider does not infer size from aspect ratio.");
     }
 
+    if (args.referenceImages.length > 9) {
+      throw new Error("Wan image models on Replicate support at most 9 reference images per request.");
+    }
+
     if (args.size) {
       const normalizedSize = parsePixelSize(args.size) ? normalizePixelSize(args.size) : normalizePresetSize(args.size);
-      if (!getAllowedWanSizes(model).has(normalizedSize)) {
+      if (!parsePixelSize(args.size) && !getAllowedWanSizes(model).has(normalizedSize)) {
         throw new Error(
-          `Wan image models on Replicate require --size to be one of ${Array.from(getAllowedWanSizes(model)).join(", ")}. Received: ${args.size}`
+          `Wan image models on Replicate require --size to be one of ${Array.from(getAllowedWanSizes(model)).join(", ")} or custom dimensions like 1920x1080. Received: ${args.size}`
         );
       }
     }

--- a/skills/baoyu-imagine/scripts/providers/replicate.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.ts
@@ -200,6 +200,12 @@ function buildWanInput(prompt: string, model: string, args: CliArgs, referenceIm
   return input;
 }
 
+export function getDefaultOutputExtension(model: string): ".png" | ".jpg" {
+  if (isSeedream45Model(model)) return ".jpg";
+  if (isSeedream5LiteModel(model)) return ".png";
+  return ".png";
+}
+
 export function validateArgs(model: string, args: CliArgs): void {
   if (isNanoBananaModel(model) && args.n > 1) {
     throw new Error("Nano Banana models on Replicate do not support --n yet because their current schema does not expose a multi-image count field.");

--- a/skills/baoyu-imagine/scripts/providers/replicate.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.ts
@@ -196,10 +196,8 @@ function buildWanInput(prompt: string, model: string, args: CliArgs, referenceIm
   }
 
   // thinking_mode only applies to pure text-to-image.
-  // image_set_mode is not exposed by the current CLI, so no extra check is needed here yet.
-  if (referenceImages.length === 0) {
-    input.thinking_mode = true;
-  }
+  // image_set_mode is not exposed by the current CLI, so switch only on input-image presence for now.
+  input.thinking_mode = referenceImages.length === 0;
 
   return input;
 }
@@ -216,6 +214,8 @@ export function validateArgs(model: string, args: CliArgs): void {
   }
 
   if (isSeedreamModel(model)) {
+    const referenceCount = args.referenceImages.length;
+
     if (args.size) {
       const normalizedSize = normalizePresetSize(args.size);
       if (!getAllowedSeedreamSizes(model).has(normalizedSize)) {
@@ -225,8 +225,18 @@ export function validateArgs(model: string, args: CliArgs): void {
       }
     }
 
+    if (referenceCount > 14) {
+      throw new Error("Seedream on Replicate supports at most 14 reference images per request.");
+    }
+
     if (args.n < 1 || args.n > 15) {
       throw new Error("Seedream on Replicate supports --n values from 1 to 15.");
+    }
+
+    if (referenceCount + args.n > 15) {
+      throw new Error(
+        `Seedream on Replicate allows at most 15 total images per request (reference images + generated images). Received ${referenceCount} reference images and --n ${args.n}.`
+      );
     }
   }
 

--- a/skills/baoyu-imagine/scripts/providers/replicate.ts
+++ b/skills/baoyu-imagine/scripts/providers/replicate.ts
@@ -2,10 +2,31 @@ import path from "node:path";
 import { readFile } from "node:fs/promises";
 import type { CliArgs } from "../types";
 
-const DEFAULT_MODEL = "google/nano-banana-pro";
+const DEFAULT_MODEL = "google/nano-banana-2";
 const SYNC_WAIT_SECONDS = 60;
 const POLL_INTERVAL_MS = 2000;
 const MAX_POLL_MS = 300_000;
+const SIZE_PRESET_PATTERN = /^\d+K$/i;
+const SEEDREAM_45_SIZES = new Set(["2K", "4K"]);
+const SEEDREAM_5_LITE_SIZES = new Set(["2K", "3K"]);
+const WAN_PRO_SIZES = new Set([
+  "1K", "2K", "4K",
+  "1024*1024", "2048*2048", "4096*4096",
+  "1280*720", "720*1280",
+  "2048*1152", "1152*2048",
+  "4096*2304", "2304*4096",
+  "1024*768", "768*1024",
+  "2048*1536", "1536*2048",
+  "4096*3072", "3072*4096",
+]);
+const WAN_SIZES = new Set([
+  "1K", "2K",
+  "1024*1024", "2048*2048",
+  "1280*720", "720*1280",
+  "2048*1152", "1152*2048",
+  "1024*768", "768*1024",
+  "2048*1536", "1536*2048",
+]);
 
 export function getDefaultModel(): string {
   return process.env.REPLICATE_IMAGE_MODEL || DEFAULT_MODEL;
@@ -31,17 +52,84 @@ export function parseModelId(model: string): { owner: string; name: string; vers
   return { owner: parts[0], name: parts[1], version: version || null };
 }
 
-export function buildInput(prompt: string, args: CliArgs, referenceImages: string[]): Record<string, unknown> {
+function isNanoBananaModel(model: string): boolean {
+  return model.startsWith("google/nano-banana");
+}
+
+function isSeedreamModel(model: string): boolean {
+  return model.startsWith("bytedance/seedream-4.5") || model.startsWith("bytedance/seedream-5-lite");
+}
+
+function isSeedream45Model(model: string): boolean {
+  return model.startsWith("bytedance/seedream-4.5");
+}
+
+function isSeedream5LiteModel(model: string): boolean {
+  return model.startsWith("bytedance/seedream-5-lite");
+}
+
+function isWanModel(model: string): boolean {
+  return model.startsWith("wan-video/wan-2.7-image");
+}
+
+function isWanProModel(model: string): boolean {
+  return model.startsWith("wan-video/wan-2.7-image-pro");
+}
+
+function parsePixelSize(size: string): { width: number; height: number } | null {
+  const match = size.trim().match(/^(\d+)\s*[xX*]\s*(\d+)$/);
+  if (!match) return null;
+
+  const width = Number.parseInt(match[1]!, 10);
+  const height = Number.parseInt(match[2]!, 10);
+
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+
+  return { width, height };
+}
+
+function normalizePixelSize(size: string): string {
+  const parsed = parsePixelSize(size);
+  if (!parsed) return size;
+  return `${parsed.width}*${parsed.height}`;
+}
+
+function isPresetSize(size: string): boolean {
+  return SIZE_PRESET_PATTERN.test(size.trim());
+}
+
+function getSeedreamDefaultSize(model: string, quality: CliArgs["quality"]): string | null {
+  if (!isSeedreamModel(model) || !quality) return null;
+  return "2K";
+}
+
+function getWanDefaultSize(quality: CliArgs["quality"]): string | null {
+  if (quality === "normal") return "1K";
+  if (quality === "2k") return "2K";
+  return null;
+}
+
+function getAllowedSeedreamSizes(model: string): Set<string> {
+  return isSeedream45Model(model) ? SEEDREAM_45_SIZES : SEEDREAM_5_LITE_SIZES;
+}
+
+function getAllowedWanSizes(model: string): Set<string> {
+  return isWanProModel(model) ? WAN_PRO_SIZES : WAN_SIZES;
+}
+
+function normalizePresetSize(size: string): string {
+  return size.trim().toUpperCase();
+}
+
+function buildNanoBananaInput(prompt: string, args: CliArgs, referenceImages: string[]): Record<string, unknown> {
   const input: Record<string, unknown> = { prompt };
 
   if (args.aspectRatio) {
     input.aspect_ratio = args.aspectRatio;
   } else if (referenceImages.length > 0) {
     input.aspect_ratio = "match_input_image";
-  }
-
-  if (args.n > 1) {
-    input.number_of_images = args.n;
   }
 
   if (args.quality === "normal") {
@@ -57,6 +145,123 @@ export function buildInput(prompt: string, args: CliArgs, referenceImages: strin
   }
 
   return input;
+}
+
+function buildSeedreamInput(prompt: string, model: string, args: CliArgs, referenceImages: string[]): Record<string, unknown> {
+  const input: Record<string, unknown> = { prompt };
+  const requestedSize = args.size || getSeedreamDefaultSize(model, args.quality);
+
+  if (requestedSize) {
+    input.size = normalizePresetSize(requestedSize);
+  }
+
+  if (args.aspectRatio) {
+    input.aspect_ratio = args.aspectRatio;
+  }
+
+  if (args.n > 1) {
+    input.sequential_image_generation = "auto";
+    input.max_images = args.n;
+  }
+
+  if (referenceImages.length > 0) {
+    input.image_input = referenceImages;
+  }
+
+  if (isSeedream5LiteModel(model)) {
+    input.output_format = "png";
+  }
+
+  return input;
+}
+
+function buildWanInput(prompt: string, model: string, args: CliArgs, referenceImages: string[]): Record<string, unknown> {
+  const input: Record<string, unknown> = { prompt };
+  const requestedSize = args.size || getWanDefaultSize(args.quality);
+
+  if (requestedSize) {
+    input.size = parsePixelSize(requestedSize) ? normalizePixelSize(requestedSize) : normalizePresetSize(requestedSize);
+  }
+
+  if (args.n > 1) {
+    input.num_outputs = args.n;
+  }
+
+  if (referenceImages.length > 0) {
+    input.images = referenceImages;
+  }
+
+  // thinking_mode only applies to pure text-to-image.
+  // image_set_mode is not exposed by the current CLI, so no extra check is needed here yet.
+  if (referenceImages.length === 0) {
+    input.thinking_mode = true;
+  }
+
+  return input;
+}
+
+export function validateArgs(model: string, args: CliArgs): void {
+  if (isNanoBananaModel(model) && args.n > 1) {
+    throw new Error("Nano Banana models on Replicate do not support --n yet because their current schema does not expose a multi-image count field.");
+  }
+
+  if (isSeedreamModel(model)) {
+    if (args.size) {
+      const normalizedSize = normalizePresetSize(args.size);
+      if (!getAllowedSeedreamSizes(model).has(normalizedSize)) {
+        throw new Error(
+          `Seedream on Replicate requires --size to be one of ${Array.from(getAllowedSeedreamSizes(model)).join(", ")}. Received: ${args.size}`
+        );
+      }
+    }
+
+    if (args.n < 1 || args.n > 15) {
+      throw new Error("Seedream on Replicate supports --n values from 1 to 15.");
+    }
+  }
+
+  if (isWanModel(model)) {
+    if (args.aspectRatio && !args.size) {
+      throw new Error("Wan image models on Replicate require --size when using --ar. This provider does not infer size from aspect ratio.");
+    }
+
+    if (args.size) {
+      const normalizedSize = parsePixelSize(args.size) ? normalizePixelSize(args.size) : normalizePresetSize(args.size);
+      if (!getAllowedWanSizes(model).has(normalizedSize)) {
+        throw new Error(
+          `Wan image models on Replicate require --size to be one of ${Array.from(getAllowedWanSizes(model)).join(", ")}. Received: ${args.size}`
+        );
+      }
+    }
+
+    if (args.n < 1 || args.n > 4) {
+      throw new Error("Wan image models on Replicate support --n values from 1 to 4 in standard mode.");
+    }
+
+    if (args.size && normalizePresetSize(args.size) === "4K" && args.referenceImages.length > 0) {
+      throw new Error("Wan 2.7 Image Pro on Replicate only supports 4K for text-to-image requests without input images.");
+    }
+  }
+}
+
+export function buildInput(
+  prompt: string,
+  model: string,
+  args: CliArgs,
+  referenceImages: string[]
+): Record<string, unknown> {
+  if (isSeedreamModel(model)) {
+    return buildSeedreamInput(prompt, model, args, referenceImages);
+  }
+
+  if (isWanModel(model)) {
+    return buildWanInput(prompt, model, args, referenceImages);
+  }
+
+  // Fall back to nano-banana schema for unknown Replicate models.
+  // This preserves backward compatibility; unsupported models will fail
+  // at API validation time if they reject nano-banana-style fields.
+  return buildNanoBananaInput(prompt, args, referenceImages);
 }
 
 async function readImageAsDataUrl(p: string): Promise<string> {
@@ -177,6 +382,8 @@ export async function generateImage(
   const apiToken = getApiToken();
   if (!apiToken) throw new Error("REPLICATE_API_TOKEN is required. Get one at https://replicate.com/account/api-tokens");
 
+  validateArgs(model, args);
+
   const parsedModel = parseModelId(model);
 
   const refDataUrls: string[] = [];
@@ -184,7 +391,7 @@ export async function generateImage(
     refDataUrls.push(await readImageAsDataUrl(refPath));
   }
 
-  const input = buildInput(prompt, args, refDataUrls);
+  const input = buildInput(prompt, model, args, refDataUrls);
 
   console.log(`Generating image with Replicate (${model})...`);
 


### PR DESCRIPTION
## Summary

This PR updates `baoyu-imagine`'s Replicate provider to handle multiple model schema families instead of assuming every Replicate image model uses the Nano Banana input shape.

It keeps the existing Nano Banana behavior as the compatibility baseline, and adds targeted support for:

- `google/nano-banana-2`
- `google/nano-banana-pro`
- `bytedance/seedream-4.5`
- `bytedance/seedream-5-lite`
- `wan-video/wan-2.7-image`
- `wan-video/wan-2.7-image-pro`

## What changed

- changed the default Replicate model in `baoyu-imagine` to `google/nano-banana-2`
- made `buildInput()` branch by model family
- preserved Nano Banana request mapping
- added Seedream-specific request mapping
- added Wan-specific request mapping
- added local validation for model-specific size and count constraints
- kept unknown Replicate models on the Nano Banana fallback path for backward compatibility
- added tests for:
  - Nano Banana mapping
  - Seedream mapping
  - Wan mapping
  - unknown-model fallback
  - validation rules
  - `generateImage()` calling validation before API requests

## Why

Replicate image models do not share one universal input schema.

The previous implementation was effectively tailored to Nano Banana-style models and sent fields like `resolution` and `output_format` to other models that reject them during schema validation.

This PR applies the minimum practical change needed to support the confirmed schema families without restructuring the provider into a larger abstraction.

## Notes

- this PR only updates `baoyu-imagine`
- `baoyu-image-gen` is left unchanged because it is deprecated
- unknown Replicate models still fall back to the Nano Banana-style request shape to preserve current behavior

## Testing

Ran:

```bash
node --import tsx --test skills/baoyu-imagine/scripts/providers/replicate.test.ts
