### PR TITLE
fix(claude-plugin): allow inline marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "baoyu-skills",
       "description": "Content generation, AI backends, and utility tools for daily work efficiency",
       "source": "./",
-      "strict": true,
+      "strict": false,
       "skills": [
         "./skills/baoyu-article-illustrator",
         "./skills/baoyu-comic",


### PR DESCRIPTION
## Summary
When trying to add this repository to Claude.ai as a marketplace plugin, I got this error:

> Plugin 'baoyu-skills' requires .claude-plugin/plugin.json (set strict: false in marketplace.json to use inline manifest)

This repository currently defines the plugin inline in `.claude-plugin/marketplace.json`, but the plugin entry is marked with `strict: true`. With strict mode enabled, Claude.ai expects a separate `.claude-plugin/plugin.json` file and refuses to install from the inline manifest alone.

This change sets `strict` to `false` so the existing inline manifest can be used as the marketplace definition. That makes the repository installable in Claude.ai marketplace without requiring an additional `plugin.json` file.

## Why this is needed
- Claude.ai marketplace rejects the current setup because strict mode requires `.claude-plugin/plugin.json`
- this repo already maintains its plugin definition inline in `marketplace.json`
- setting `strict` to `false` aligns the manifest format with how the repo is currently structured

## Validation
- I manually tested this change when adding the repository to Claude.ai as a marketplace plugin
- after changing `strict` to `false`, the marketplace installation worked for me
- also confirmed `.claude-plugin/marketplace.json` remains valid JSON