### PR TITLE
fix(gemini-webapi): add fallback scan for generated images when wants_generated fails

### DIFF
--- a/skills/baoyu-danger-gemini-web/scripts/gemini-webapi/client.ts
+++ b/skills/baoyu-danger-gemini-web/scripts/gemini-webapi/client.ts
@@ -459,6 +459,32 @@ export class GeminiClient extends GemMixin {
             }
           }
 
+          // Fallback: unconditionally scan all response parts for generated image URLs.
+          // The `wants_generated` detection above relies on `candidate[12][7][0]` and an old
+          // `googleusercontent.com/image_generation_content/` URL pattern, both of which no
+          // longer appear in the current Gemini Web API response format.
+          // When Gemini does generate images, their URLs now start with
+          // `https://lh3.googleusercontent.com/gg-dl/` and are present somewhere in the
+          // response parts — this fallback finds them so images are not silently dropped.
+          if (generated_images.length === 0) {
+            for (let part_index = body_index; part_index < (response_json as unknown[]).length; part_index++) {
+              const part = (response_json as unknown[])[part_index];
+              if (!Array.isArray(part)) continue;
+              const part_body = get_nested_value<string | null>(part, [2], null);
+              if (!part_body) continue;
+              try {
+                const part_json = JSON.parse(part_body) as unknown[];
+                const cand = get_nested_value<unknown>(part_json, [4, candidate_index], null);
+                if (!cand) continue;
+                const urls = collect_strings(cand, (s) => s.startsWith('https://lh3.googleusercontent.com/gg-dl/'), 4);
+                for (const url of urls) {
+                  generated_images.push(new GeneratedImage(url, '[Generated Image]', '', this.proxy, this.cookies));
+                }
+                if (generated_images.length > 0) break;
+              } catch {}
+            }
+          }
+
           out.push(new Candidate({ rcid, text, thoughts, web_images, generated_images }));
         }
 


### PR DESCRIPTION
## Problem

When asking Gemini to generate images, the skill throws **"No image returned in response"** even though Gemini successfully generates the image (visible in the web UI).

**Root cause:** The `wants_generated` gate in `client.ts` uses two detection conditions, both of which no longer match the current Gemini Web API response format:

1. `get_nested_value(candidate, [12, 7, 0], null) != null` — this path no longer exists in new responses
2. `/http:\/\/googleusercontent\.com\/image_generation_content\/\d+/.test(text)` — this URL pattern no longer appears in the response text

Because `wants_generated` is always `false`, the entire image-extraction block is skipped, and `generated_images` stays empty.

## Fix

Add an unconditional fallback **after** the `if (wants_generated)` block. When `generated_images` is still empty, it scans all response parts for `https://lh3.googleusercontent.com/gg-dl/` URLs (the current format for Gemini-generated images) using the already-present `collect_strings` helper.

Key properties of this fix:
- **Backward-compatible** — the fallback only runs when `generated_images.length === 0`, so old response formats are unaffected
- **Minimal** — reuses existing `collect_strings` and `GeneratedImage` without new dependencies
- **No behaviour change for non-image responses** — if no `gg-dl/` URLs exist, nothing extra is pushed

## Tested

Verified locally: 4 image-generation prompts, all successfully downloaded after the patch.
