### PR TITLE
fix(browser): ensure tab activation before copy/paste in WeChat editor

### DIFF
--- a/skills/baoyu-post-to-wechat/scripts/wechat-article.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-article.ts
@@ -180,6 +180,10 @@ async function copyHtmlFromBrowser(cdp: CdpConnection, htmlFilePath: string, con
   }, { sessionId });
   await sleep(300);
 
+  console.log('[wechat] Activating HTML tab for copy...');
+  await cdp.send('Target.activateTarget', { targetId });
+  await sleep(300);
+
   console.log('[wechat] Copying content...');
   await sendCopy(cdp, sessionId);
   await sleep(1000);
@@ -189,6 +193,11 @@ async function copyHtmlFromBrowser(cdp: CdpConnection, htmlFilePath: string, con
 }
 
 async function pasteFromClipboardInEditor(session: ChromeSession): Promise<void> {
+  console.log('[wechat] Activating editor tab for paste...');
+  if (session.targetId) {
+    await session.cdp.send('Target.activateTarget', { targetId: session.targetId });
+    await sleep(300);
+  }
   console.log('[wechat] Pasting content...');
   await sendPaste(session.cdp, session.sessionId);
   await sleep(1000);


### PR DESCRIPTION
## Problem

When posting articles via browser automation (wechat-article.ts), the HTML content copy and editor paste operations sometimes fail silently. The editor body remains empty after paste, while the title and author fields are filled correctly.

## Root Cause

The script opens the HTML preview in a new tab, selects content via CDP, and then uses AppleScript Cmd+C to copy. However, Cmd+C operates on the frontmost application window/tab, not the tab where the CDP selection was made. If the editor tab is still frontmost, the copy captures nothing (or captures the empty editor). The same issue affects paste: when pasting images into the editor, the editor tab may not be active.

## Fix

Add Target.activateTarget CDP calls before both copy and paste operations:

1. Before copy: Activate the HTML preview tab so AppleScript Cmd+C copies the selected HTML content.
2. Before paste: Activate the editor tab so AppleScript Cmd+V pastes into the correct location.

### Files Changed

- skills/baoyu-post-to-wechat/scripts/wechat-article.ts
  - copyHtmlFromBrowser(): Added cdp.send('Target.activateTarget', { targetId }) before sendCopy()
  - pasteFromClipboardInEditor(): Added cdp.send('Target.activateTarget', { targetId: session.targetId }) before sendPaste()

## Testing

Tested locally on macOS with Chrome browser automation. Three articles with 9, 8, and 8 inline images were successfully posted to WeChat Official Account after applying this fix. Previously, the same workflow left the editor body empty.