### PR TITLE
Enable remote WeChat API publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ Post content to WeChat Official Account (微信公众号). Two modes available:
 | Method | Speed | Requirements |
 |--------|-------|--------------|
 | API (Recommended) | Fast | API credentials |
+| Remote API | Fast | API credentials + SSH server IP whitelisted in WeChat |
 | Browser | Slow | Chrome, login session |
 
 **API Configuration** (for faster publishing):
@@ -628,6 +629,19 @@ To obtain credentials:
 2. Go to: 我的业务 → 公众号 → 开发密钥
 3. Create development key and copy AppID/AppSecret
 4. Add your machine's IP to the whitelist
+
+**Remote API Publishing**: If the WeChat API whitelist only allows a cloud server, set `default_publish_method: remote-api` and configure SSH:
+
+```yaml
+remote_publish_host: your.server.ip
+remote_publish_user: root
+remote_publish_port: 22
+remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
+remote_publish_cleanup: 1
+remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+```
+
+The local machine still converts Markdown/HTML, then uploads temporary payloads to the remote server. The remote server calls WeChat APIs from its whitelisted IP and cleans up by default. Use SSH key login; do not store SSH passwords in config.
 
 **Browser Method** (no API setup needed): Requires Google Chrome. First run opens browser for QR code login (session preserved).
 
@@ -657,10 +671,11 @@ accounts:
     app_secret: your_wechat_app_secret
   - name: AI Newsletter
     alias: ai-news
-    default_publish_method: browser
+    default_publish_method: remote-api
     default_author: AI Newsletter
     need_open_comment: 1
     only_fans_can_comment: 0
+    remote_publish_host: your.server.ip
 ```
 
 | Accounts configured | Behavior |

--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ accounts:
     app_secret: your_wechat_app_secret
   - name: AI Newsletter
     alias: ai-news
-    default_publish_method: remote-api
+    default_publish_method: browser
     default_author: AI Newsletter
     need_open_comment: 1
     only_fans_can_comment: 0

--- a/README.md
+++ b/README.md
@@ -638,10 +638,16 @@ remote_publish_user: root
 remote_publish_port: 22
 remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
 remote_publish_cleanup: 1
-remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+remote_publish_identity_file: /path/to/id_ed25519
+remote_publish_known_hosts_file: /path/to/known_hosts
+remote_publish_strict_host_key_checking: accept-new
+remote_publish_connect_timeout: 10
+remote_publish_proxy_jump:
 ```
 
-The local machine still converts Markdown/HTML, then uploads temporary payloads to the remote server. The remote server calls WeChat APIs from its whitelisted IP and cleans up by default. Use SSH key login; do not store SSH passwords in config.
+Raw `ssh`/`scp` options are intentionally unsupported. Use only the whitelisted remote SSH keys above so config cannot inject `ProxyCommand`, `-F`, or other local command execution surfaces.
+
+The local machine still converts Markdown/HTML, downloads and validates remote images, then uploads only staged local payload files to the remote server. The remote server calls WeChat APIs from its whitelisted IP and cleans up by default. WeChat AppSecret is passed to the remote publisher over SSH stdin and is not written into the remote payload directory. Use SSH key login; do not store SSH passwords in config.
 
 **Browser Method** (no API setup needed): Requires Google Chrome. First run opens browser for QR code login (session preserved).
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -613,6 +613,7 @@ clawhub install baoyu-markdown-to-html
 | 方式 | 速度 | 要求 |
 |------|------|------|
 | API（推荐） | 快 | API 凭证 |
+| 远程 API | 快 | API 凭证 + 已加入微信白名单的远程服务器 IP |
 | 浏览器 | 慢 | Chrome，登录会话 |
 
 **API 配置**（更快的发布方式）：
@@ -628,6 +629,19 @@ WECHAT_APP_SECRET=你的AppSecret
 2. 进入：我的业务 → 公众号 → 开发密钥
 3. 添加开发密钥，复制 AppID 和 AppSecret
 4. 将你操作的机器 IP 加入白名单
+
+**远程 API 发布**：如果公众号 API 白名单只配置了云服务器 IP，可以设置 `default_publish_method: remote-api` 并配置 SSH：
+
+```yaml
+remote_publish_host: your.server.ip
+remote_publish_user: root
+remote_publish_port: 22
+remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
+remote_publish_cleanup: 1
+remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+```
+
+本地仍负责 Markdown/HTML 转换，然后把临时 HTML、图片和发布脚本上传到远程服务器，由远程服务器调用微信 API，默认发布后清理临时目录。需要 SSH key 登录，不要在配置里保存服务器密码。
 
 **浏览器方式**（无需 API 配置）：需已安装 Google Chrome，首次运行需扫码登录（登录状态会保存）
 
@@ -657,10 +671,11 @@ accounts:
     app_secret: 你的微信AppSecret
   - name: AI 工具集
     alias: ai-tools
-    default_publish_method: browser
+    default_publish_method: remote-api
     default_author: AI 工具集
     need_open_comment: 1
     only_fans_can_comment: 0
+    remote_publish_host: your.server.ip
 ```
 
 | 账号配置情况 | 行为 |

--- a/README.zh.md
+++ b/README.zh.md
@@ -638,10 +638,16 @@ remote_publish_user: root
 remote_publish_port: 22
 remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
 remote_publish_cleanup: 1
-remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+remote_publish_identity_file: /path/to/id_ed25519
+remote_publish_known_hosts_file: /path/to/known_hosts
+remote_publish_strict_host_key_checking: accept-new
+remote_publish_connect_timeout: 10
+remote_publish_proxy_jump:
 ```
 
-本地仍负责 Markdown/HTML 转换，然后把临时 HTML、图片和发布脚本上传到远程服务器，由远程服务器调用微信 API，默认发布后清理临时目录。需要 SSH key 登录，不要在配置里保存服务器密码。
+原始 `ssh`/`scp` 选项已故意禁用，只能使用上面白名单内的远程 SSH 配置，避免通过 `ProxyCommand`、`-F` 等注入本地命令执行面。
+
+本地仍负责 Markdown/HTML 转换，并在本地下载、校验远程图片，只把已暂存的本地 payload 文件上传到远程服务器。远程服务器只调用微信 API，默认发布后清理临时目录。AppSecret 通过 SSH stdin 传给远端发布进程，不写入远端 payload 目录。需要 SSH key 登录，不要在配置里保存服务器密码。
 
 **浏览器方式**（无需 API 配置）：需已安装 Google Chrome，首次运行需扫码登录（登录状态会保存）
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -677,7 +677,7 @@ accounts:
     app_secret: 你的微信AppSecret
   - name: AI 工具集
     alias: ai-tools
-    default_publish_method: remote-api
+    default_publish_method: browser
     default_author: AI 工具集
     need_open_comment: 1
     only_fans_can_comment: 0

--- a/skills/baoyu-post-to-wechat/SKILL.md
+++ b/skills/baoyu-post-to-wechat/SKILL.md
@@ -74,8 +74,14 @@ remote_publish_user: root
 remote_publish_port: 22
 remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
 remote_publish_cleanup: 1
-remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+remote_publish_identity_file: /path/to/id_ed25519
+remote_publish_known_hosts_file: /path/to/known_hosts
+remote_publish_strict_host_key_checking: accept-new
+remote_publish_connect_timeout: 10
+remote_publish_proxy_jump:
 ```
+
+Raw `ssh`/`scp` options are intentionally unsupported. Use only the whitelisted remote SSH keys above so config cannot inject `ProxyCommand`, `-F`, or other local command execution surfaces.
 
 **Theme options**: default, grace, simple, modern. **Color presets**: blue, green, vermilion, yellow, purple, sky, rose, olive, black, gray, pink, red, orange (or hex).
 
@@ -199,10 +205,10 @@ Always pass `--theme` even if it's `default`. Only pass `--color` when explicitl
 **Remote API method** (accepts `.md` or `.html`):
 
 ```bash
-${BUN_X} {baseDir}/scripts/wechat-api.ts <file> --theme <theme> --remote [--remote-host <host>] [--remote-user <user>] [--remote-port <port>] [--remote-workdir <path>] [--remote-ssh-option <arg>]
+${BUN_X} {baseDir}/scripts/wechat-api.ts <file> --theme <theme> --remote [--remote-host <host>] [--remote-user <user>] [--remote-port <port>] [--remote-workdir <path>] [--remote-identity-file <path>] [--remote-strict-host-key-checking <yes|no|accept-new>]
 ```
 
-Use this when WeChat API IP whitelist allows only a cloud server: conversion still happens locally, then temporary HTML/image payloads plus a small Python publisher are copied to the remote server with `ssh`/`scp`; the remote server calls WeChat APIs and then deletes the temporary directory by default. Requires SSH key login. Never store SSH passwords in EXTEND.md.
+Use this when WeChat API IP whitelist allows only a cloud server: conversion and remote-image download/validation happen locally, then temporary HTML/image payloads plus a small Python publisher are copied to the remote server with `ssh`/`scp`; the remote server calls WeChat APIs and then deletes the temporary directory by default. AppSecret is passed over SSH stdin instead of being copied into the remote directory. Requires SSH key login. Never store SSH passwords in EXTEND.md.
 
 **Browser method** (accepts `--markdown` or `--html`):
 
@@ -262,7 +268,7 @@ Files created:
 | Missing API credentials | Follow guided setup in Step 2 |
 | Access token error | Verify credentials valid and not expired |
 | Remote publish host missing | Set `remote_publish_host` in EXTEND.md or pass `--remote-host` |
-| Remote publish SSH fails | Verify SSH key login, `remote_publish_user`, `remote_publish_port`, and `remote_publish_ssh_options` |
+| Remote publish SSH fails | Verify SSH key login, `remote_publish_user`, `remote_publish_port`, and `remote_publish_identity_file` / `remote_publish_known_hosts_file` / `remote_publish_strict_host_key_checking` / `remote_publish_connect_timeout` / `remote_publish_proxy_jump` |
 | Not logged in (browser) | First run opens browser — scan QR to log in. Set `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` to receive the QR image via Telegram |
 | Chrome not found | Set `WECHAT_BROWSER_CHROME_PATH` |
 | Title/summary missing | Use auto-generation or provide manually |

--- a/skills/baoyu-post-to-wechat/SKILL.md
+++ b/skills/baoyu-post-to-wechat/SKILL.md
@@ -69,6 +69,12 @@ default_author: 宝玉
 need_open_comment: 1
 only_fans_can_comment: 0
 chrome_profile_path: /path/to/chrome/profile
+remote_publish_host:
+remote_publish_user: root
+remote_publish_port: 22
+remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
+remote_publish_cleanup: 1
+remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
 ```
 
 **Theme options**: default, grace, simple, modern. **Color presets**: blue, green, vermilion, yellow, purple, sky, rose, olive, black, gray, pink, red, orange (or hex).
@@ -149,6 +155,7 @@ Ask method unless specified in EXTEND.md or CLI:
 | Method | Speed | Requires |
 |--------|-------|----------|
 | `api` (Recommended) | Fast | API credentials |
+| `remote-api` | Fast | API credentials + SSH server whose IP is whitelisted in WeChat |
 | `browser` | Slow | Chrome + logged-in session |
 
 **API selected + missing credentials** → run guided setup per `references/api-setup.md` (writes to `.baoyu-skills/.env`).
@@ -188,6 +195,14 @@ Always pass `--theme` even if it's `default`. Only pass `--color` when explicitl
 - `article_type`: `news` (default) or `newspic`
 - For `news`, include `thumb_media_id` (cover required)
 - Always include `need_open_comment` (default `1`) and `only_fans_can_comment` (default `0`) in the request body, even if the CLI doesn't expose them
+
+**Remote API method** (accepts `.md` or `.html`):
+
+```bash
+${BUN_X} {baseDir}/scripts/wechat-api.ts <file> --theme <theme> --remote [--remote-host <host>] [--remote-user <user>] [--remote-port <port>] [--remote-workdir <path>] [--remote-ssh-option <arg>]
+```
+
+Use this when WeChat API IP whitelist allows only a cloud server: conversion still happens locally, then temporary HTML/image payloads plus a small Python publisher are copied to the remote server with `ssh`/`scp`; the remote server calls WeChat APIs and then deletes the temporary directory by default. Requires SSH key login. Never store SSH passwords in EXTEND.md.
 
 **Browser method** (accepts `--markdown` or `--html`):
 
@@ -237,6 +252,7 @@ Files created:
 | Comment control | ✗ | ✓ | ✗ |
 | Requires Chrome | ✓ | ✗ | ✓ |
 | Requires API credentials | ✗ | ✓ | ✗ |
+| Supports remote server IP publishing | ✗ | ✓ (`--remote`) | ✗ |
 | Speed | Medium | Fast | Slow |
 
 ## Troubleshooting
@@ -245,6 +261,8 @@ Files created:
 |-------|-----|
 | Missing API credentials | Follow guided setup in Step 2 |
 | Access token error | Verify credentials valid and not expired |
+| Remote publish host missing | Set `remote_publish_host` in EXTEND.md or pass `--remote-host` |
+| Remote publish SSH fails | Verify SSH key login, `remote_publish_user`, `remote_publish_port`, and `remote_publish_ssh_options` |
 | Not logged in (browser) | First run opens browser — scan QR to log in. Set `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` to receive the QR image via Telegram |
 | Chrome not found | Set `WECHAT_BROWSER_CHROME_PATH` |
 | Title/summary missing | Use auto-generation or provide manually |

--- a/skills/baoyu-post-to-wechat/references/config/first-time-setup.md
+++ b/skills/baoyu-post-to-wechat/references/config/first-time-setup.md
@@ -84,6 +84,8 @@ question: "Default publishing method?"
 options:
   - label: "api (Recommended)"
     description: "Fast, requires API credentials (AppID + AppSecret)"
+  - label: "remote-api"
+    description: "Fast, uses a remote server IP over SSH for WeChat API whitelist"
   - label: "browser"
     description: "Slow, requires Chrome and login session"
 ```
@@ -157,11 +159,17 @@ options:
 ```md
 default_theme: [default/grace/simple/modern]
 default_color: [preset name, hex, or empty for theme default]
-default_publish_method: [api/browser]
+default_publish_method: [api/remote-api/browser]
 default_author: [author name or empty]
 need_open_comment: [1/0]
 only_fans_can_comment: [1/0]
 chrome_profile_path:
+remote_publish_host: [remote server host or empty]
+remote_publish_user: root
+remote_publish_port: 22
+remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
+remote_publish_cleanup: 1
+remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
 ```
 
 ### Multi-Account
@@ -174,15 +182,21 @@ accounts:
   - name: [display name]
     alias: [short key, e.g. "baoyu"]
     default: true
-    default_publish_method: [api/browser]
+    default_publish_method: [api/remote-api/browser]
     default_author: [author name]
     need_open_comment: [1/0]
     only_fans_can_comment: [1/0]
     app_id: [WeChat App ID, optional]
     app_secret: [WeChat App Secret, optional]
+    remote_publish_host: [remote server host, optional]
+    remote_publish_user: root
+    remote_publish_port: 22
+    remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
+    remote_publish_cleanup: 1
+    remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
   - name: [second account name]
     alias: [short key, e.g. "ai-tools"]
-    default_publish_method: [api/browser]
+    default_publish_method: [api/remote-api/browser]
     default_author: [author name]
     need_open_comment: [1/0]
     only_fans_can_comment: [1/0]

--- a/skills/baoyu-post-to-wechat/references/config/first-time-setup.md
+++ b/skills/baoyu-post-to-wechat/references/config/first-time-setup.md
@@ -169,8 +169,14 @@ remote_publish_user: root
 remote_publish_port: 22
 remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
 remote_publish_cleanup: 1
-remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+remote_publish_identity_file: /path/to/id_ed25519
+remote_publish_known_hosts_file: /path/to/known_hosts
+remote_publish_strict_host_key_checking: accept-new
+remote_publish_connect_timeout: 10
+remote_publish_proxy_jump:
 ```
+
+Raw `ssh`/`scp` options are intentionally unsupported. Use only the whitelisted remote SSH keys above so config cannot inject `ProxyCommand`, `-F`, or other local command execution surfaces.
 
 ### Multi-Account
 
@@ -193,7 +199,11 @@ accounts:
     remote_publish_port: 22
     remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
     remote_publish_cleanup: 1
-    remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    remote_publish_identity_file: /path/to/id_ed25519
+    remote_publish_known_hosts_file: /path/to/known_hosts
+    remote_publish_strict_host_key_checking: accept-new
+    remote_publish_connect_timeout: 10
+    remote_publish_proxy_jump:
   - name: [second account name]
     alias: [short key, e.g. "ai-tools"]
     default_publish_method: [api/remote-api/browser]

--- a/skills/baoyu-post-to-wechat/references/multi-account.md
+++ b/skills/baoyu-post-to-wechat/references/multi-account.md
@@ -37,7 +37,7 @@ accounts:
 
 ## Per-Account vs Global Keys
 
-**Per-account** (also accepted globally as fallback): `default_publish_method`, `default_author`, `need_open_comment`, `only_fans_can_comment`, `app_id`, `app_secret`, `chrome_profile_path`, `remote_publish_host`, `remote_publish_user`, `remote_publish_port`, `remote_publish_workdir`, `remote_publish_cleanup`, `remote_publish_ssh_options`.
+**Per-account** (also accepted globally as fallback): `default_publish_method`, `default_author`, `need_open_comment`, `only_fans_can_comment`, `app_id`, `app_secret`, `chrome_profile_path`, `remote_publish_host`, `remote_publish_user`, `remote_publish_port`, `remote_publish_workdir`, `remote_publish_cleanup`, `remote_publish_identity_file` / `remote_publish_known_hosts_file` / `remote_publish_strict_host_key_checking` / `remote_publish_connect_timeout` / `remote_publish_proxy_jump`.
 
 **Global-only** (always shared): `default_theme`, `default_color`.
 
@@ -117,7 +117,13 @@ accounts:
     remote_publish_port: 22
     remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
     remote_publish_cleanup: 1
-    remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    remote_publish_identity_file: /path/to/id_ed25519
+    remote_publish_known_hosts_file: /path/to/known_hosts
+    remote_publish_strict_host_key_checking: accept-new
+    remote_publish_connect_timeout: 10
+    remote_publish_proxy_jump:
 ```
 
-Remote publishing copies only temporary HTML/image payloads, credentials, and a small Python publisher over SSH/SCP. The remote host calls WeChat APIs from its own IP and deletes the temporary directory by default. Configure SSH key login; do not store SSH passwords in EXTEND.md.
+Raw `ssh`/`scp` options are intentionally unsupported. Use only the whitelisted remote SSH keys above so config cannot inject `ProxyCommand`, `-F`, or other local command execution surfaces.
+
+Remote publishing copies only temporary HTML/image payloads and a small Python publisher over SSH/SCP. Remote image URLs are downloaded and validated locally before staging; the remote host never fetches arbitrary article image URLs. AppSecret is passed over SSH stdin instead of being written to the remote directory. The remote host calls WeChat APIs from its own IP and deletes the temporary directory by default. Configure SSH key login; do not store SSH passwords in EXTEND.md.

--- a/skills/baoyu-post-to-wechat/references/multi-account.md
+++ b/skills/baoyu-post-to-wechat/references/multi-account.md
@@ -37,7 +37,7 @@ accounts:
 
 ## Per-Account vs Global Keys
 
-**Per-account** (also accepted globally as fallback): `default_publish_method`, `default_author`, `need_open_comment`, `only_fans_can_comment`, `app_id`, `app_secret`, `chrome_profile_path`.
+**Per-account** (also accepted globally as fallback): `default_publish_method`, `default_author`, `need_open_comment`, `only_fans_can_comment`, `app_id`, `app_secret`, `chrome_profile_path`, `remote_publish_host`, `remote_publish_user`, `remote_publish_port`, `remote_publish_workdir`, `remote_publish_cleanup`, `remote_publish_ssh_options`.
 
 **Global-only** (always shared): `default_theme`, `default_color`.
 
@@ -96,6 +96,28 @@ All publishing scripts accept `--account <alias>`:
 
 ```bash
 ${BUN_X} {baseDir}/scripts/wechat-api.ts <file> --theme default --account ai-tools
+${BUN_X} {baseDir}/scripts/wechat-api.ts <file> --theme default --account ai-tools --remote
 ${BUN_X} {baseDir}/scripts/wechat-article.ts --markdown <file> --theme default --account baoyu
 ${BUN_X} {baseDir}/scripts/wechat-browser.ts --markdown <file> --images ./photos/ --account baoyu
 ```
+
+## Remote API Publishing
+
+Use `default_publish_method: remote-api` or pass `--remote` when the WeChat API whitelist points at a cloud server rather than the local machine.
+
+```md
+accounts:
+  - name: AI工具集
+    alias: ai-tools
+    default_publish_method: remote-api
+    app_id: your_ai_tools_wechat_app_id
+    app_secret: your_ai_tools_wechat_app_secret
+    remote_publish_host: your.server.ip
+    remote_publish_user: root
+    remote_publish_port: 22
+    remote_publish_workdir: /tmp/baoyu-wechat-remote-publish
+    remote_publish_cleanup: 1
+    remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+```
+
+Remote publishing copies only temporary HTML/image payloads, credentials, and a small Python publisher over SSH/SCP. The remote host calls WeChat APIs from its own IP and deletes the temporary directory by default. Configure SSH key login; do not store SSH passwords in EXTEND.md.

--- a/skills/baoyu-post-to-wechat/scripts/remote_publisher.py
+++ b/skills/baoyu-post-to-wechat/scripts/remote_publisher.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Minimal remote WeChat draft publisher.
+
+The TypeScript caller performs all markdown rendering, image fetching,
+validation, and staging. This remote script only reads staged local files,
+receives WeChat credentials on stdin, calls the WeChat API from the remote
+server IP, and prints a compact JSON result.
+"""
+
+from __future__ import annotations
+
+import json
+import mimetypes
+import re
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from uuid import uuid4
+
+API = "https://api.weixin.qq.com"
+ROOT = Path(__file__).resolve().parent
+def request_json(url: str, data=None, headers=None):
+    body = None
+    if data is not None:
+        body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        headers = {"Content-Type": "application/json; charset=utf-8", **(headers or {})}
+    req = urllib.request.Request(url, data=body, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        raw = resp.read().decode("utf-8")
+    obj = json.loads(raw)
+    if obj.get("errcode") not in (None, 0):
+        raise RuntimeError(f"WeChat API error {obj.get('errcode')}: {obj.get('errmsg')}")
+    return obj
+
+
+def load_asset(asset: dict):
+    if "remote_url" in asset:
+        raise RuntimeError("remote_url assets are forbidden; stage remote images locally before upload")
+
+    file_path = (ROOT / "images" / asset["filename"]).resolve()
+    images_root = (ROOT / "images").resolve()
+    if images_root not in file_path.parents:
+        raise RuntimeError("asset path escapes images directory")
+    return (
+        file_path.read_bytes(),
+        asset["filename"],
+        asset.get("content_type") or mimetypes.guess_type(file_path.name)[0] or "application/octet-stream",
+    )
+
+
+def multipart_upload(url: str, asset: dict):
+    data, filename, content_type = load_asset(asset)
+    boundary = f"----baoyu-wechat-{uuid4().hex}"
+    body = b"".join([
+        f"--{boundary}\r\n".encode(),
+        f'Content-Disposition: form-data; name="media"; filename="{filename}"\r\n'.encode(),
+        f"Content-Type: {content_type}\r\n\r\n".encode(),
+        data,
+        b"\r\n",
+        f"--{boundary}--\r\n".encode(),
+    ])
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        raw = resp.read().decode("utf-8")
+    obj = json.loads(raw)
+    if obj.get("errcode") not in (None, 0):
+        raise RuntimeError(f"WeChat upload error {obj.get('errcode')}: {obj.get('errmsg')}")
+    return obj
+
+
+def get_token(appid: str, secret: str) -> str:
+    query = urllib.parse.urlencode({
+        "grant_type": "client_credential",
+        "appid": appid,
+        "secret": secret,
+    })
+    return request_json(f"{API}/cgi-bin/token?{query}")["access_token"]
+
+
+def upload_body_image(token: str, asset: dict) -> str:
+    obj = multipart_upload(
+        f"{API}/cgi-bin/media/uploadimg?access_token={urllib.parse.quote(token)}",
+        asset,
+    )
+    url = obj["url"]
+    return "https://" + url[len("http://"):] if url.startswith("http://") else url
+
+
+def upload_material(token: str, asset: dict) -> str:
+    obj = multipart_upload(
+        f"{API}/cgi-bin/material/add_material?access_token={urllib.parse.quote(token)}&type=image",
+        asset,
+    )
+    return obj["media_id"]
+
+
+def replace_placeholder(html: str, placeholder: str, replacement: str) -> str:
+    """Replace a placeholder only when it is not part of a longer numbered token."""
+    escaped = re.escape(placeholder)
+    return re.sub(rf"{escaped}(?!\d)", replacement, html)
+
+
+def publish_to_draft(token: str, payload: dict, content: str, thumb_media_id: str | None, image_media_ids: list[str]):
+    article_type = payload["article_type"]
+    article = {
+        "article_type": article_type,
+        "title": payload["title"],
+        "content": content,
+        "need_open_comment": payload.get("need_open_comment", 1),
+        "only_fans_can_comment": payload.get("only_fans_can_comment", 0),
+    }
+    if payload.get("author"):
+        article["author"] = payload["author"]
+
+    if article_type == "newspic":
+        article["image_info"] = {
+            "image_list": [{"image_media_id": item} for item in image_media_ids],
+        }
+    else:
+        article["thumb_media_id"] = thumb_media_id
+        if payload.get("digest"):
+            article["digest"] = payload["digest"]
+
+    return request_json(
+        f"{API}/cgi-bin/draft/add?access_token={urllib.parse.quote(token)}",
+        {"articles": [article]},
+    )
+
+
+def main() -> None:
+    payload = json.loads((ROOT / "payload.json").read_text(encoding="utf-8"))
+    secrets = json.loads(sys.stdin.read())
+    token = get_token(secrets["app_id"], secrets["app_secret"])
+
+    html = payload["html"]
+    image_media_ids: list[str] = []
+    thumb_media_id = None
+    body_uploads = 0
+
+    for item in payload.get("html_images", []):
+        src = item["src"]
+        body_asset = item.get("body")
+        if body_asset:
+            image_url = upload_body_image(token, body_asset)
+            html = html.replace(src, image_url)
+            body_uploads += 1
+
+        if item.get("material"):
+            media_id = upload_material(token, item["material"])
+            if payload["article_type"] == "newspic":
+                image_media_ids.append(media_id)
+            if payload.get("collect_news_cover_fallback") and not thumb_media_id:
+                thumb_media_id = media_id
+
+    for item in payload.get("placeholder_images", []):
+        image_url = upload_body_image(token, item["body"])
+        replacement = f'<img src="{image_url}" style="display: block; width: 100%; margin: 1.5em auto;">'
+        html = replace_placeholder(html, item["placeholder"], replacement)
+        body_uploads += 1
+
+        if item.get("material"):
+            media_id = upload_material(token, item["material"])
+            if payload["article_type"] == "newspic":
+                image_media_ids.append(media_id)
+            if payload.get("collect_news_cover_fallback") and not thumb_media_id:
+                thumb_media_id = media_id
+
+    if payload.get("cover"):
+        thumb_media_id = upload_material(token, payload["cover"])
+
+    if payload["article_type"] == "news" and not thumb_media_id:
+        raise RuntimeError("news article requires thumb_media_id")
+    if payload["article_type"] == "newspic" and not image_media_ids:
+        raise RuntimeError("newspic requires at least one image_media_id")
+
+    result = publish_to_draft(token, payload, html, thumb_media_id, image_media_ids)
+    print(json.dumps({
+        "media_id": result.get("media_id"),
+        "title": payload["title"],
+        "body_images": body_uploads,
+        "image_media_ids": len(image_media_ids),
+    }, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
@@ -502,7 +502,11 @@ Options:
   --remote-user <user>       SSH user (default: root)
   --remote-port <port>       SSH port (default: 22)
   --remote-workdir <path>    Remote work directory (default: /tmp/baoyu-wechat-remote-publish)
-  --remote-ssh-option <arg>  Extra SSH/SCP option, can repeat
+  --remote-identity-file <path>       SSH identity file
+  --remote-known-hosts-file <path>    SSH known_hosts file
+  --remote-strict-host-key-checking <yes|no|accept-new>
+  --remote-connect-timeout <seconds>
+  --remote-proxy-jump <host>          SSH ProxyJump value
   --no-remote-cleanup        Keep remote temp directory after publish
   --no-cite           Disable bottom citations for ordinary external links in markdown mode
   --dry-run           Parse and render only, don't publish
@@ -555,7 +559,11 @@ interface CliArgs {
   remotePort?: number;
   remoteWorkdir?: string;
   remoteCleanup?: boolean;
-  remoteSshOptions: string[];
+  remoteIdentityFile?: string;
+  remoteKnownHostsFile?: string;
+  remoteStrictHostKeyChecking?: "yes" | "no" | "accept-new";
+  remoteConnectTimeout?: number;
+  remoteProxyJump?: string;
   citeStatus: boolean;
   dryRun: boolean;
 }
@@ -571,7 +579,6 @@ function parseArgs(argv: string[]): CliArgs {
     articleType: "news",
     theme: "default",
     remote: false,
-    remoteSshOptions: [],
     citeStatus: true,
     dryRun: false,
   };
@@ -612,9 +619,25 @@ function parseArgs(argv: string[]): CliArgs {
     } else if (arg === "--remote-workdir" && argv[i + 1]) {
       args.remote = true;
       args.remoteWorkdir = argv[++i];
-    } else if (arg === "--remote-ssh-option" && argv[i + 1]) {
+    } else if (arg === "--remote-identity-file" && argv[i + 1]) {
       args.remote = true;
-      args.remoteSshOptions.push(argv[++i]!);
+      args.remoteIdentityFile = argv[++i];
+    } else if (arg === "--remote-known-hosts-file" && argv[i + 1]) {
+      args.remote = true;
+      args.remoteKnownHostsFile = argv[++i];
+    } else if (arg === "--remote-strict-host-key-checking" && argv[i + 1]) {
+      args.remote = true;
+      const value = argv[++i]!.toLowerCase();
+      if (value === "yes" || value === "no" || value === "accept-new") {
+        args.remoteStrictHostKeyChecking = value;
+      }
+    } else if (arg === "--remote-connect-timeout" && argv[i + 1]) {
+      args.remote = true;
+      const timeout = Number.parseInt(argv[++i]!, 10);
+      if (Number.isInteger(timeout) && timeout > 0) args.remoteConnectTimeout = timeout;
+    } else if (arg === "--remote-proxy-jump" && argv[i + 1]) {
+      args.remote = true;
+      args.remoteProxyJump = argv[++i];
     } else if (arg === "--no-remote-cleanup") {
       args.remote = true;
       args.remoteCleanup = false;
@@ -654,9 +677,10 @@ function parseEnvBool(value?: string): boolean | undefined {
   return undefined;
 }
 
-function parseEnvList(value?: string): string[] | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed.split(/\s+/).filter(Boolean) : undefined;
+function parseStrictHostKeyChecking(value?: string): "yes" | "no" | "accept-new" | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "yes" || normalized === "no" || normalized === "accept-new") return normalized;
+  return undefined;
 }
 
 function buildRemoteConfig(args: CliArgs, resolved: ReturnType<typeof resolveAccount>): RemotePublishConfig {
@@ -666,9 +690,15 @@ function buildRemoteConfig(args: CliArgs, resolved: ReturnType<typeof resolveAcc
     port: args.remotePort || resolved.remote_publish_port || parseEnvPort(process.env.WECHAT_REMOTE_PORT),
     workdir: args.remoteWorkdir || resolved.remote_publish_workdir || process.env.WECHAT_REMOTE_WORKDIR,
     cleanup: args.remoteCleanup ?? resolved.remote_publish_cleanup ?? parseEnvBool(process.env.WECHAT_REMOTE_CLEANUP),
-    sshOptions: args.remoteSshOptions.length > 0
-      ? args.remoteSshOptions
-      : resolved.remote_publish_ssh_options || parseEnvList(process.env.WECHAT_REMOTE_SSH_OPTIONS),
+    identityFile: args.remoteIdentityFile || resolved.remote_publish_identity_file || process.env.WECHAT_REMOTE_IDENTITY_FILE,
+    knownHostsFile: args.remoteKnownHostsFile || resolved.remote_publish_known_hosts_file || process.env.WECHAT_REMOTE_KNOWN_HOSTS_FILE,
+    strictHostKeyChecking: args.remoteStrictHostKeyChecking
+      || resolved.remote_publish_strict_host_key_checking
+      || parseStrictHostKeyChecking(process.env.WECHAT_REMOTE_STRICT_HOST_KEY_CHECKING),
+    connectTimeout: args.remoteConnectTimeout
+      || resolved.remote_publish_connect_timeout
+      || parseEnvPort(process.env.WECHAT_REMOTE_CONNECT_TIMEOUT),
+    proxyJump: args.remoteProxyJump || resolved.remote_publish_proxy_jump || process.env.WECHAT_REMOTE_PROXY_JUMP,
   };
 }
 

--- a/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { loadWechatExtendConfig, resolveAccount, loadCredentials } from "./wechat-extend-config.ts";
+import { publishRemoteDraft, type RemotePublishConfig } from "./wechat-remote-publish.ts";
 import {
   type WechatUploadAsset,
   prepareWechatBodyImageUpload,
@@ -438,14 +439,18 @@ function renderMarkdownWithPlaceholders(
   const mdToWechatScript = path.join(__dirname, "md-to-wechat.ts");
   const baseDir = path.dirname(markdownPath);
 
-  const args = ["-y", "bun", mdToWechatScript, markdownPath];
+  const bunCheck = spawnSync("bun", ["--version"], { stdio: "ignore" });
+  const command = bunCheck.status === 0 ? "bun" : "npx";
+  const args = command === "bun"
+    ? [mdToWechatScript, markdownPath]
+    : ["-y", "bun", mdToWechatScript, markdownPath];
   if (title) args.push("--title", title);
   if (theme) args.push("--theme", theme);
   if (color) args.push("--color", color);
   if (!citeStatus) args.push("--no-cite");
 
   console.error(`[wechat-api] Rendering markdown with placeholders via md-to-wechat: ${theme}${color ? `, color: ${color}` : ""}, citeStatus: ${citeStatus}`);
-  const result = spawnSync("npx", args, {
+  const result = spawnSync(command, args, {
     stdio: ["inherit", "pipe", "pipe"],
     cwd: baseDir,
   });
@@ -492,6 +497,13 @@ Options:
   --color <name|hex>  Primary color (blue, green, vermilion, etc. or hex)
   --cover <path>      Cover image path (local or URL)
   --account <alias>   Select account by alias (for multi-account setups)
+  --remote            Publish from a configured remote server IP over SSH
+  --remote-host <host>       Remote server host/IP
+  --remote-user <user>       SSH user (default: root)
+  --remote-port <port>       SSH port (default: 22)
+  --remote-workdir <path>    Remote work directory (default: /tmp/baoyu-wechat-remote-publish)
+  --remote-ssh-option <arg>  Extra SSH/SCP option, can repeat
+  --no-remote-cleanup        Keep remote temp directory after publish
   --no-cite           Disable bottom citations for ordinary external links in markdown mode
   --dry-run           Parse and render only, don't publish
   --help              Show this help
@@ -537,6 +549,13 @@ interface CliArgs {
   color?: string;
   cover?: string;
   account?: string;
+  remote: boolean;
+  remoteHost?: string;
+  remoteUser?: string;
+  remotePort?: number;
+  remoteWorkdir?: string;
+  remoteCleanup?: boolean;
+  remoteSshOptions: string[];
   citeStatus: boolean;
   dryRun: boolean;
 }
@@ -551,6 +570,8 @@ function parseArgs(argv: string[]): CliArgs {
     isHtml: false,
     articleType: "news",
     theme: "default",
+    remote: false,
+    remoteSshOptions: [],
     citeStatus: true,
     dryRun: false,
   };
@@ -576,6 +597,27 @@ function parseArgs(argv: string[]): CliArgs {
       args.cover = argv[++i];
     } else if (arg === "--account" && argv[i + 1]) {
       args.account = argv[++i];
+    } else if (arg === "--remote") {
+      args.remote = true;
+    } else if (arg === "--remote-host" && argv[i + 1]) {
+      args.remote = true;
+      args.remoteHost = argv[++i];
+    } else if (arg === "--remote-user" && argv[i + 1]) {
+      args.remote = true;
+      args.remoteUser = argv[++i];
+    } else if (arg === "--remote-port" && argv[i + 1]) {
+      args.remote = true;
+      const port = Number.parseInt(argv[++i]!, 10);
+      if (Number.isInteger(port) && port > 0) args.remotePort = port;
+    } else if (arg === "--remote-workdir" && argv[i + 1]) {
+      args.remote = true;
+      args.remoteWorkdir = argv[++i];
+    } else if (arg === "--remote-ssh-option" && argv[i + 1]) {
+      args.remote = true;
+      args.remoteSshOptions.push(argv[++i]!);
+    } else if (arg === "--no-remote-cleanup") {
+      args.remote = true;
+      args.remoteCleanup = false;
     } else if (arg === "--cite") {
       args.citeStatus = true;
     } else if (arg === "--no-cite") {
@@ -597,6 +639,37 @@ function parseArgs(argv: string[]): CliArgs {
   args.isHtml = args.filePath.toLowerCase().endsWith(".html");
 
   return args;
+}
+
+function parseEnvPort(value?: string): number | undefined {
+  const parsed = Number.parseInt(value || "", 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseEnvBool(value?: string): boolean | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function parseEnvList(value?: string): string[] | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.split(/\s+/).filter(Boolean) : undefined;
+}
+
+function buildRemoteConfig(args: CliArgs, resolved: ReturnType<typeof resolveAccount>): RemotePublishConfig {
+  return {
+    host: args.remoteHost || resolved.remote_publish_host || process.env.WECHAT_REMOTE_HOST || "",
+    user: args.remoteUser || resolved.remote_publish_user || process.env.WECHAT_REMOTE_USER,
+    port: args.remotePort || resolved.remote_publish_port || parseEnvPort(process.env.WECHAT_REMOTE_PORT),
+    workdir: args.remoteWorkdir || resolved.remote_publish_workdir || process.env.WECHAT_REMOTE_WORKDIR,
+    cleanup: args.remoteCleanup ?? resolved.remote_publish_cleanup ?? parseEnvBool(process.env.WECHAT_REMOTE_CLEANUP),
+    sshOptions: args.remoteSshOptions.length > 0
+      ? args.remoteSshOptions
+      : resolved.remote_publish_ssh_options || parseEnvList(process.env.WECHAT_REMOTE_SSH_OPTIONS),
+  };
 }
 
 function extractHtmlTitle(html: string): string {
@@ -709,8 +782,6 @@ async function main(): Promise<void> {
     console.error(`[wechat-api] Skipped incomplete credential source: ${skippedSource}`);
   }
   console.error(`[wechat-api] Credentials source: ${creds.source}`);
-  console.error("[wechat-api] Fetching access token...");
-  const accessToken = await fetchAccessToken(creds.appId, creds.appSecret);
 
   const rawCoverPath = args.cover ||
     frontmatter.coverImage ||
@@ -721,6 +792,37 @@ async function main(): Promise<void> {
     ? path.resolve(process.cwd(), rawCoverPath)
     : rawCoverPath;
   const needNewsCoverFallback = args.articleType === "news" && !coverPath;
+
+  if (args.remote || resolved.default_publish_method === "remote-api") {
+    const remote = buildRemoteConfig(args, resolved);
+    console.error(`[wechat-api] Remote publish host: ${remote.host || "(not configured)"}`);
+    const remoteResult = await publishRemoteDraft({
+      remote,
+      appId: creds.appId,
+      appSecret: creds.appSecret,
+      title,
+      author,
+      digest,
+      html: htmlContent,
+      baseDir,
+      contentImages,
+      coverPath,
+      articleType: args.articleType,
+      needOpenComment: resolved.need_open_comment,
+      onlyFansCanComment: resolved.only_fans_can_comment,
+    });
+    console.log(JSON.stringify({
+      media_id: remoteResult.mediaId,
+      title: remoteResult.title,
+      method: "remote-api",
+      body_images: remoteResult.bodyImages,
+      image_media_ids: remoteResult.imageMediaIds,
+    }, null, 2));
+    return;
+  }
+
+  console.error("[wechat-api] Fetching access token...");
+  const accessToken = await fetchAccessToken(creds.appId, creds.appSecret);
 
   console.error("[wechat-api] Uploading body images...");
   const { html: processedHtml, firstCoverMediaId, imageMediaIds } = await uploadImagesInHtml(

--- a/skills/baoyu-post-to-wechat/scripts/wechat-extend-config.test.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-extend-config.test.ts
@@ -158,7 +158,11 @@ remote_publish_user: deploy
 remote_publish_port: 2222
 remote_publish_workdir: /tmp/global-wechat
 remote_publish_cleanup: 0
-remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+remote_publish_identity_file: /keys/global_ed25519
+remote_publish_known_hosts_file: /keys/known_hosts
+remote_publish_strict_host_key_checking: accept-new
+remote_publish_connect_timeout: 10
+remote_publish_proxy_jump: jump.example.com
 
 accounts:
   - name: Tech
@@ -167,6 +171,7 @@ accounts:
     remote_publish_host: account.example.com
     remote_publish_user: root
     remote_publish_port: 2200
+    remote_publish_strict_host_key_checking: yes
 `);
 
   const config = loadWechatExtendConfig();
@@ -178,10 +183,9 @@ accounts:
   assert.equal(resolved.remote_publish_port, 2200);
   assert.equal(resolved.remote_publish_workdir, "/tmp/global-wechat");
   assert.equal(resolved.remote_publish_cleanup, false);
-  assert.deepEqual(resolved.remote_publish_ssh_options, [
-    "-o",
-    "BatchMode=yes",
-    "-o",
-    "StrictHostKeyChecking=accept-new",
-  ]);
+  assert.equal(resolved.remote_publish_identity_file, "/keys/global_ed25519");
+  assert.equal(resolved.remote_publish_known_hosts_file, "/keys/known_hosts");
+  assert.equal(resolved.remote_publish_strict_host_key_checking, "yes");
+  assert.equal(resolved.remote_publish_connect_timeout, 10);
+  assert.equal(resolved.remote_publish_proxy_jump, "jump.example.com");
 });

--- a/skills/baoyu-post-to-wechat/scripts/wechat-extend-config.test.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-extend-config.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import process from "node:process";
 import test, { type TestContext } from "node:test";
 
-import { loadCredentials } from "./wechat-extend-config.ts";
+import { loadCredentials, loadWechatExtendConfig, resolveAccount } from "./wechat-extend-config.ts";
 
 function useCwd(t: TestContext, cwd: string): void {
   const previous = process.cwd();
@@ -73,6 +73,12 @@ async function writeEnvFile(root: string, content: string): Promise<void> {
   await fs.writeFile(envPath, content);
 }
 
+async function writeExtendFile(root: string, content: string): Promise<void> {
+  const extendPath = path.join(root, ".baoyu-skills", "baoyu-post-to-wechat", "EXTEND.md");
+  await fs.mkdir(path.dirname(extendPath), { recursive: true });
+  await fs.writeFile(extendPath, content);
+}
+
 test("loadCredentials selects the first complete source without mixing values across sources", async (t) => {
   const cwdRoot = await makeTempDir("wechat-creds-cwd-");
   const homeRoot = await makeTempDir("wechat-creds-home-");
@@ -136,4 +142,46 @@ test("loadCredentials reports skipped incomplete sources when no complete pair e
     () => loadCredentials(),
     /Incomplete credential sources skipped:\n- process\.env missing WECHAT_APP_SECRET\n- <cwd>\/\.baoyu-skills\/\.env missing WECHAT_APP_ID/,
   );
+});
+
+test("loadWechatExtendConfig resolves remote publish settings globally and per account", async (t) => {
+  const cwdRoot = await makeTempDir("wechat-extend-cwd-");
+  const homeRoot = await makeTempDir("wechat-extend-home-");
+
+  useCwd(t, cwdRoot);
+  useHome(t, homeRoot);
+
+  await writeExtendFile(cwdRoot, `
+default_publish_method: remote-api
+remote_publish_host: global.example.com
+remote_publish_user: deploy
+remote_publish_port: 2222
+remote_publish_workdir: /tmp/global-wechat
+remote_publish_cleanup: 0
+remote_publish_ssh_options: -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+
+accounts:
+  - name: Tech
+    alias: tech
+    default: true
+    remote_publish_host: account.example.com
+    remote_publish_user: root
+    remote_publish_port: 2200
+`);
+
+  const config = loadWechatExtendConfig();
+  const resolved = resolveAccount(config);
+
+  assert.equal(resolved.default_publish_method, "remote-api");
+  assert.equal(resolved.remote_publish_host, "account.example.com");
+  assert.equal(resolved.remote_publish_user, "root");
+  assert.equal(resolved.remote_publish_port, 2200);
+  assert.equal(resolved.remote_publish_workdir, "/tmp/global-wechat");
+  assert.equal(resolved.remote_publish_cleanup, false);
+  assert.deepEqual(resolved.remote_publish_ssh_options, [
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "StrictHostKeyChecking=accept-new",
+  ]);
 });

--- a/skills/baoyu-post-to-wechat/scripts/wechat-extend-config.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-extend-config.ts
@@ -18,7 +18,11 @@ export interface WechatAccount {
   remote_publish_port?: number;
   remote_publish_workdir?: string;
   remote_publish_cleanup?: boolean;
-  remote_publish_ssh_options?: string[];
+  remote_publish_identity_file?: string;
+  remote_publish_known_hosts_file?: string;
+  remote_publish_strict_host_key_checking?: "yes" | "no" | "accept-new";
+  remote_publish_connect_timeout?: number;
+  remote_publish_proxy_jump?: string;
 }
 
 export interface WechatExtendConfig {
@@ -34,7 +38,11 @@ export interface WechatExtendConfig {
   remote_publish_port?: number;
   remote_publish_workdir?: string;
   remote_publish_cleanup?: boolean;
-  remote_publish_ssh_options?: string[];
+  remote_publish_identity_file?: string;
+  remote_publish_known_hosts_file?: string;
+  remote_publish_strict_host_key_checking?: "yes" | "no" | "accept-new";
+  remote_publish_connect_timeout?: number;
+  remote_publish_proxy_jump?: string;
   accounts?: WechatAccount[];
 }
 
@@ -53,7 +61,11 @@ export interface ResolvedAccount {
   remote_publish_port?: number;
   remote_publish_workdir?: string;
   remote_publish_cleanup?: boolean;
-  remote_publish_ssh_options?: string[];
+  remote_publish_identity_file?: string;
+  remote_publish_known_hosts_file?: string;
+  remote_publish_strict_host_key_checking?: "yes" | "no" | "accept-new";
+  remote_publish_connect_timeout?: number;
+  remote_publish_proxy_jump?: string;
 }
 
 function stripQuotes(s: string): string {
@@ -78,20 +90,12 @@ function toOptionalPort(v?: string): number | undefined {
   return Number.isInteger(port) && port > 0 ? port : undefined;
 }
 
-function parseListValue(v?: string): string[] | undefined {
-  if (!v) return undefined;
-  const trimmed = v.trim();
-  if (!trimmed) return undefined;
-  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-    try {
-      const parsed = JSON.parse(trimmed.replace(/'/g, '"'));
-      if (Array.isArray(parsed) && parsed.every(item => typeof item === "string")) {
-        return parsed;
-      }
-    } catch {}
-  }
-  return trimmed.split(/\s+/).filter(Boolean);
+function toStrictHostKeyChecking(v?: string): "yes" | "no" | "accept-new" | undefined {
+  const normalized = v?.trim().toLowerCase();
+  if (normalized === "yes" || normalized === "no" || normalized === "accept-new") return normalized;
+  return undefined;
 }
+
 
 function parseWechatExtend(content: string): WechatExtendConfig {
   const config: WechatExtendConfig = {};
@@ -158,7 +162,11 @@ function parseWechatExtend(content: string): WechatExtendConfig {
       case "remote_publish_port": config.remote_publish_port = toOptionalPort(val); break;
       case "remote_publish_workdir": config.remote_publish_workdir = val; break;
       case "remote_publish_cleanup": config.remote_publish_cleanup = toOptionalBool(val); break;
-      case "remote_publish_ssh_options": config.remote_publish_ssh_options = parseListValue(val); break;
+      case "remote_publish_identity_file": config.remote_publish_identity_file = val; break;
+      case "remote_publish_known_hosts_file": config.remote_publish_known_hosts_file = val; break;
+      case "remote_publish_strict_host_key_checking": config.remote_publish_strict_host_key_checking = toStrictHostKeyChecking(val); break;
+      case "remote_publish_connect_timeout": config.remote_publish_connect_timeout = toOptionalPort(val); break;
+      case "remote_publish_proxy_jump": config.remote_publish_proxy_jump = val; break;
     }
   }
 
@@ -181,7 +189,11 @@ function parseWechatExtend(content: string): WechatExtendConfig {
       remote_publish_port: toOptionalPort(a.remote_publish_port),
       remote_publish_workdir: a.remote_publish_workdir || undefined,
       remote_publish_cleanup: toOptionalBool(a.remote_publish_cleanup),
-      remote_publish_ssh_options: parseListValue(a.remote_publish_ssh_options),
+      remote_publish_identity_file: a.remote_publish_identity_file || undefined,
+      remote_publish_known_hosts_file: a.remote_publish_known_hosts_file || undefined,
+      remote_publish_strict_host_key_checking: toStrictHostKeyChecking(a.remote_publish_strict_host_key_checking),
+      remote_publish_connect_timeout: toOptionalPort(a.remote_publish_connect_timeout),
+      remote_publish_proxy_jump: a.remote_publish_proxy_jump || undefined,
     }));
   }
 
@@ -232,7 +244,11 @@ export function resolveAccount(config: WechatExtendConfig, alias?: string): Reso
     remote_publish_port: acct?.remote_publish_port ?? config.remote_publish_port,
     remote_publish_workdir: acct?.remote_publish_workdir ?? config.remote_publish_workdir,
     remote_publish_cleanup: acct?.remote_publish_cleanup ?? config.remote_publish_cleanup,
-    remote_publish_ssh_options: acct?.remote_publish_ssh_options ?? config.remote_publish_ssh_options,
+    remote_publish_identity_file: acct?.remote_publish_identity_file ?? config.remote_publish_identity_file,
+    remote_publish_known_hosts_file: acct?.remote_publish_known_hosts_file ?? config.remote_publish_known_hosts_file,
+    remote_publish_strict_host_key_checking: acct?.remote_publish_strict_host_key_checking ?? config.remote_publish_strict_host_key_checking,
+    remote_publish_connect_timeout: acct?.remote_publish_connect_timeout ?? config.remote_publish_connect_timeout,
+    remote_publish_proxy_jump: acct?.remote_publish_proxy_jump ?? config.remote_publish_proxy_jump,
   };
 }
 

--- a/skills/baoyu-post-to-wechat/scripts/wechat-extend-config.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-extend-config.ts
@@ -13,6 +13,12 @@ export interface WechatAccount {
   app_id?: string;
   app_secret?: string;
   chrome_profile_path?: string;
+  remote_publish_host?: string;
+  remote_publish_user?: string;
+  remote_publish_port?: number;
+  remote_publish_workdir?: string;
+  remote_publish_cleanup?: boolean;
+  remote_publish_ssh_options?: string[];
 }
 
 export interface WechatExtendConfig {
@@ -23,6 +29,12 @@ export interface WechatExtendConfig {
   need_open_comment?: number;
   only_fans_can_comment?: number;
   chrome_profile_path?: string;
+  remote_publish_host?: string;
+  remote_publish_user?: string;
+  remote_publish_port?: number;
+  remote_publish_workdir?: string;
+  remote_publish_cleanup?: boolean;
+  remote_publish_ssh_options?: string[];
   accounts?: WechatAccount[];
 }
 
@@ -36,6 +48,12 @@ export interface ResolvedAccount {
   app_id?: string;
   app_secret?: string;
   chrome_profile_path?: string;
+  remote_publish_host?: string;
+  remote_publish_user?: string;
+  remote_publish_port?: number;
+  remote_publish_workdir?: string;
+  remote_publish_cleanup?: boolean;
+  remote_publish_ssh_options?: string[];
 }
 
 function stripQuotes(s: string): string {
@@ -44,6 +62,35 @@ function stripQuotes(s: string): string {
 
 function toBool01(v: string): number {
   return v === "1" || v === "true" ? 1 : 0;
+}
+
+function toOptionalBool(v?: string): boolean | undefined {
+  if (v === undefined) return undefined;
+  const normalized = v.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function toOptionalPort(v?: string): number | undefined {
+  if (v === undefined) return undefined;
+  const port = Number.parseInt(v, 10);
+  return Number.isInteger(port) && port > 0 ? port : undefined;
+}
+
+function parseListValue(v?: string): string[] | undefined {
+  if (!v) return undefined;
+  const trimmed = v.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    try {
+      const parsed = JSON.parse(trimmed.replace(/'/g, '"'));
+      if (Array.isArray(parsed) && parsed.every(item => typeof item === "string")) {
+        return parsed;
+      }
+    } catch {}
+  }
+  return trimmed.split(/\s+/).filter(Boolean);
 }
 
 function parseWechatExtend(content: string): WechatExtendConfig {
@@ -106,6 +153,12 @@ function parseWechatExtend(content: string): WechatExtendConfig {
       case "need_open_comment": config.need_open_comment = toBool01(val); break;
       case "only_fans_can_comment": config.only_fans_can_comment = toBool01(val); break;
       case "chrome_profile_path": config.chrome_profile_path = val; break;
+      case "remote_publish_host": config.remote_publish_host = val; break;
+      case "remote_publish_user": config.remote_publish_user = val; break;
+      case "remote_publish_port": config.remote_publish_port = toOptionalPort(val); break;
+      case "remote_publish_workdir": config.remote_publish_workdir = val; break;
+      case "remote_publish_cleanup": config.remote_publish_cleanup = toOptionalBool(val); break;
+      case "remote_publish_ssh_options": config.remote_publish_ssh_options = parseListValue(val); break;
     }
   }
 
@@ -123,6 +176,12 @@ function parseWechatExtend(content: string): WechatExtendConfig {
       app_id: a.app_id || undefined,
       app_secret: a.app_secret || undefined,
       chrome_profile_path: a.chrome_profile_path || undefined,
+      remote_publish_host: a.remote_publish_host || undefined,
+      remote_publish_user: a.remote_publish_user || undefined,
+      remote_publish_port: toOptionalPort(a.remote_publish_port),
+      remote_publish_workdir: a.remote_publish_workdir || undefined,
+      remote_publish_cleanup: toOptionalBool(a.remote_publish_cleanup),
+      remote_publish_ssh_options: parseListValue(a.remote_publish_ssh_options),
     }));
   }
 
@@ -168,6 +227,12 @@ export function resolveAccount(config: WechatExtendConfig, alias?: string): Reso
     app_id: acct?.app_id,
     app_secret: acct?.app_secret,
     chrome_profile_path: acct?.chrome_profile_path ?? config.chrome_profile_path,
+    remote_publish_host: acct?.remote_publish_host ?? config.remote_publish_host,
+    remote_publish_user: acct?.remote_publish_user ?? config.remote_publish_user,
+    remote_publish_port: acct?.remote_publish_port ?? config.remote_publish_port,
+    remote_publish_workdir: acct?.remote_publish_workdir ?? config.remote_publish_workdir,
+    remote_publish_cleanup: acct?.remote_publish_cleanup ?? config.remote_publish_cleanup,
+    remote_publish_ssh_options: acct?.remote_publish_ssh_options ?? config.remote_publish_ssh_options,
   };
 }
 

--- a/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.test.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const publisherPath = path.join(__dirname, "remote_publisher.py");
+
+function runPython(code: string): string {
+  const result = spawnSync("python3", ["-c", code], {
+    encoding: "utf-8",
+    env: { ...process.env, REMOTE_PUBLISHER_PATH: publisherPath },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+test("remote Python publisher replaces numbered placeholders with a digit boundary", () => {
+  const stdout = runPython(String.raw`
+import importlib.util
+import os
+spec = importlib.util.spec_from_file_location("remote_publisher", os.environ["REMOTE_PUBLISHER_PATH"])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+print(mod.replace_placeholder("WECHATIMGPH_10 WECHATIMGPH_1 WECHATIMGPH_11", "WECHATIMGPH_1", "<img>"))
+`);
+
+  assert.equal(stdout, "WECHATIMGPH_10 <img> WECHATIMGPH_11");
+});
+
+test("remote Python publisher rejects remote_url assets", () => {
+  const stdout = runPython(String.raw`
+import importlib.util
+import os
+spec = importlib.util.spec_from_file_location("remote_publisher", os.environ["REMOTE_PUBLISHER_PATH"])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+try:
+    mod.load_asset({"remote_url": "https://example.com/a.png", "filename": "a.png"})
+except RuntimeError as exc:
+    print(str(exc))
+`);
+
+  assert.match(stdout, /remote_url assets are forbidden/);
+});
+
+
+test("remote TypeScript publisher does not emit remote URL payloads or remote credential files", () => {
+  const source = fs.readFileSync(path.join(__dirname, "wechat-remote-publish.ts"), "utf8");
+  assert.doesNotMatch(source, /remote_url\s*:/);
+  assert.doesNotMatch(source, /wechat\.json/);
+  assert.doesNotMatch(source, /sshOptions\s*\?:\s*string\[\]/);
+});

--- a/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.test.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { isPrivateAddress, resolvePublicHttpsUrl } from "./wechat-remote-publish.ts";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const publisherPath = path.join(__dirname, "remote_publisher.py");
@@ -49,9 +51,52 @@ except RuntimeError as exc:
 });
 
 
+test("remote URL validation allows normal public HTTPS hostnames", async () => {
+  const resolved = await resolvePublicHttpsUrl("https://cdn.example.com/path/a.png", async (hostname) => {
+    assert.equal(hostname, "cdn.example.com");
+    return [{ address: "93.184.216.34", family: 4 }];
+  });
+
+  assert.equal(resolved.url.hostname, "cdn.example.com");
+  assert.equal(resolved.address.address, "93.184.216.34");
+});
+
+test("remote URL validation rejects localhost and private or link-local addresses", async () => {
+  await assert.rejects(
+    () => resolvePublicHttpsUrl("https://localhost/a.png"),
+    /host is not allowed/,
+  );
+  await assert.rejects(
+    () => resolvePublicHttpsUrl("https://127.0.0.1/a.png"),
+    /private address/,
+  );
+  await assert.rejects(
+    () => resolvePublicHttpsUrl("https://169.254.169.254/latest/meta-data"),
+    /private address/,
+  );
+  await assert.rejects(
+    () => resolvePublicHttpsUrl("https://[fe80::1]/a.png"),
+    /private address/,
+  );
+  await assert.rejects(
+    () => resolvePublicHttpsUrl("https://cdn.example.com/a.png", async () => [{ address: "10.0.0.5", family: 4 }]),
+    /private address/,
+  );
+});
+
+test("remote URL validation treats non-IP hostnames as DNS names, not private addresses", () => {
+  assert.equal(isPrivateAddress("cdn.example.com"), false);
+  assert.equal(isPrivateAddress("192.168.1.10"), true);
+  assert.equal(isPrivateAddress("93.184.216.34"), false);
+});
+
+
 test("remote TypeScript publisher does not emit remote URL payloads or remote credential files", () => {
   const source = fs.readFileSync(path.join(__dirname, "wechat-remote-publish.ts"), "utf8");
   assert.doesNotMatch(source, /remote_url\s*:/);
   assert.doesNotMatch(source, /wechat\.json/);
   assert.doesNotMatch(source, /sshOptions\s*\?:\s*string\[\]/);
+  assert.doesNotMatch(source, /fetch\s*\(/);
+  assert.match(source, /https\.request/);
+  assert.match(source, /lookup:/);
 });

--- a/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.ts
@@ -1,0 +1,516 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+
+import {
+  type WechatUploadAsset,
+  prepareWechatBodyImageUpload,
+  needsWechatBodyImageProcessing,
+  detectImageFormatFromBuffer,
+} from "./wechat-image-processor.ts";
+
+export interface RemotePublishConfig {
+  host: string;
+  user?: string;
+  port?: number;
+  workdir?: string;
+  cleanup?: boolean;
+  sshOptions?: string[];
+}
+
+interface RemoteImageInfo {
+  placeholder: string;
+  localPath: string;
+  originalPath: string;
+}
+
+export interface RemotePublishOptions {
+  remote: RemotePublishConfig;
+  appId: string;
+  appSecret: string;
+  title: string;
+  author?: string;
+  digest?: string;
+  html: string;
+  baseDir: string;
+  contentImages?: RemoteImageInfo[];
+  coverPath?: string;
+  articleType: "news" | "newspic";
+  needOpenComment: number;
+  onlyFansCanComment: number;
+}
+
+export interface RemotePublishResult {
+  mediaId: string;
+  title: string;
+  bodyImages: number;
+  imageMediaIds: number;
+}
+
+interface StagedAssetRef {
+  filename?: string;
+  content_type?: string;
+  remote_url?: string;
+}
+
+interface StagedHtmlImage {
+  src: string;
+  body?: StagedAssetRef;
+  material?: StagedAssetRef;
+}
+
+interface StagedPlaceholderImage {
+  placeholder: string;
+  body: StagedAssetRef;
+  material?: StagedAssetRef;
+}
+
+const REMOTE_PUBLISHER = String.raw`#!/usr/bin/env python3
+import json
+import mimetypes
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from uuid import uuid4
+
+API = "https://api.weixin.qq.com"
+ROOT = Path(__file__).resolve().parent
+
+
+def request_json(url, data=None, headers=None):
+    body = None
+    if data is not None:
+        body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        headers = {"Content-Type": "application/json; charset=utf-8", **(headers or {})}
+    req = urllib.request.Request(url, data=body, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        raw = resp.read().decode("utf-8")
+    obj = json.loads(raw)
+    if obj.get("errcode") not in (None, 0):
+        raise RuntimeError(f"WeChat API error {obj.get('errcode')}: {obj.get('errmsg')}")
+    return obj
+
+
+def load_asset(asset):
+    if asset.get("remote_url"):
+        req = urllib.request.Request(asset["remote_url"], headers={"User-Agent": "baoyu-post-to-wechat/remote"})
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            data = resp.read()
+            content_type = resp.headers.get("content-type") or asset.get("content_type") or "image/jpeg"
+        filename = Path(urllib.parse.urlparse(asset["remote_url"]).path).name or f"remote-{uuid4().hex}.jpg"
+        return data, filename, content_type
+
+    file_path = ROOT / "images" / asset["filename"]
+    return (
+        file_path.read_bytes(),
+        asset["filename"],
+        asset.get("content_type") or mimetypes.guess_type(file_path.name)[0] or "application/octet-stream",
+    )
+
+
+def multipart_upload(url, asset):
+    data, filename, content_type = load_asset(asset)
+    boundary = f"----baoyu-wechat-{uuid4().hex}"
+    body = b"".join([
+        f"--{boundary}\r\n".encode(),
+        f'Content-Disposition: form-data; name="media"; filename="{filename}"\r\n'.encode(),
+        f"Content-Type: {content_type}\r\n\r\n".encode(),
+        data,
+        b"\r\n",
+        f"--{boundary}--\r\n".encode(),
+    ])
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        raw = resp.read().decode("utf-8")
+    obj = json.loads(raw)
+    if obj.get("errcode") not in (None, 0):
+        raise RuntimeError(f"WeChat upload error {obj.get('errcode')}: {obj.get('errmsg')}")
+    return obj
+
+
+def get_token(appid, secret):
+    query = urllib.parse.urlencode({
+        "grant_type": "client_credential",
+        "appid": appid,
+        "secret": secret,
+    })
+    return request_json(f"{API}/cgi-bin/token?{query}")["access_token"]
+
+
+def upload_body_image(token, asset):
+    obj = multipart_upload(
+        f"{API}/cgi-bin/media/uploadimg?access_token={urllib.parse.quote(token)}",
+        asset,
+    )
+    url = obj["url"]
+    return "https://" + url[len("http://"):] if url.startswith("http://") else url
+
+
+def upload_material(token, asset):
+    obj = multipart_upload(
+        f"{API}/cgi-bin/material/add_material?access_token={urllib.parse.quote(token)}&type=image",
+        asset,
+    )
+    return obj["media_id"]
+
+
+def replace_all_placeholders(html, placeholder, replacement):
+    return html.replace(placeholder, replacement)
+
+
+def publish_to_draft(token, payload, content, thumb_media_id, image_media_ids):
+    article_type = payload["article_type"]
+    article = {
+        "article_type": article_type,
+        "title": payload["title"],
+        "content": content,
+        "need_open_comment": payload.get("need_open_comment", 1),
+        "only_fans_can_comment": payload.get("only_fans_can_comment", 0),
+    }
+    if payload.get("author"):
+        article["author"] = payload["author"]
+
+    if article_type == "newspic":
+        article["image_info"] = {
+            "image_list": [{"image_media_id": item} for item in image_media_ids],
+        }
+    else:
+        article["thumb_media_id"] = thumb_media_id
+        if payload.get("digest"):
+            article["digest"] = payload["digest"]
+
+    return request_json(
+        f"{API}/cgi-bin/draft/add?access_token={urllib.parse.quote(token)}",
+        {"articles": [article]},
+    )
+
+
+def main():
+    payload = json.loads((ROOT / "payload.json").read_text(encoding="utf-8"))
+    secrets = json.loads((ROOT / "wechat.json").read_text(encoding="utf-8"))
+    token = get_token(secrets["app_id"], secrets["app_secret"])
+
+    html = payload["html"]
+    image_media_ids = []
+    thumb_media_id = None
+    body_uploads = 0
+
+    for item in payload.get("html_images", []):
+        src = item["src"]
+        if src.startswith("https://mmbiz.qpic.cn"):
+            if payload.get("collect_news_cover_fallback") and not thumb_media_id:
+                thumb_media_id = upload_material(token, {"remote_url": src, "content_type": "image/jpeg"})
+            continue
+
+        body_asset = item.get("body")
+        if body_asset:
+            image_url = upload_body_image(token, body_asset)
+            html = html.replace(src, image_url)
+            body_uploads += 1
+
+        if item.get("material"):
+            media_id = upload_material(token, item["material"])
+            if payload["article_type"] == "newspic":
+                image_media_ids.append(media_id)
+            if payload.get("collect_news_cover_fallback") and not thumb_media_id:
+                thumb_media_id = media_id
+
+    for item in payload.get("placeholder_images", []):
+        image_url = upload_body_image(token, item["body"])
+        replacement = f'<img src="{image_url}" style="display: block; width: 100%; margin: 1.5em auto;">'
+        html = replace_all_placeholders(html, item["placeholder"], replacement)
+        body_uploads += 1
+
+        if item.get("material"):
+            media_id = upload_material(token, item["material"])
+            if payload["article_type"] == "newspic":
+                image_media_ids.append(media_id)
+            if payload.get("collect_news_cover_fallback") and not thumb_media_id:
+                thumb_media_id = media_id
+
+    if payload.get("cover"):
+        thumb_media_id = upload_material(token, payload["cover"])
+
+    if payload["article_type"] == "news" and not thumb_media_id:
+        raise RuntimeError("news article requires thumb_media_id")
+    if payload["article_type"] == "newspic" and not image_media_ids:
+        raise RuntimeError("newspic requires at least one image_media_id")
+
+    result = publish_to_draft(token, payload, html, thumb_media_id, image_media_ids)
+    print(json.dumps({
+        "media_id": result.get("media_id"),
+        "title": payload["title"],
+        "body_images": body_uploads,
+        "image_media_ids": len(image_media_ids),
+    }, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()
+`;
+
+function shQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function normalizeRemoteConfig(remote: RemotePublishConfig): Required<RemotePublishConfig> {
+  const host = remote.host?.trim();
+  if (!host) throw new Error("Remote publish requires remote_publish_host.");
+
+  return {
+    host,
+    user: remote.user?.trim() || "root",
+    port: remote.port || 22,
+    workdir: remote.workdir?.trim() || "/tmp/baoyu-wechat-remote-publish",
+    cleanup: remote.cleanup ?? true,
+    sshOptions: remote.sshOptions || [],
+  };
+}
+
+function uniqueName(name: string, used: Set<string>): string {
+  const safe = path.basename(name) || `asset-${randomUUID()}`;
+  if (!used.has(safe)) {
+    used.add(safe);
+    return safe;
+  }
+
+  const ext = path.extname(safe);
+  const stem = path.basename(safe, ext);
+  while (true) {
+    const candidate = `${stem}-${randomUUID().slice(0, 8)}${ext}`;
+    if (!used.has(candidate)) {
+      used.add(candidate);
+      return candidate;
+    }
+  }
+}
+
+function resolveLocalPath(imagePath: string, baseDir: string): string {
+  return path.isAbsolute(imagePath) ? imagePath : path.resolve(baseDir, imagePath);
+}
+
+async function loadUploadAsset(imagePath: string, baseDir: string): Promise<WechatUploadAsset | { remoteUrl: string }> {
+  if (imagePath.startsWith("http://") || imagePath.startsWith("https://")) {
+    return { remoteUrl: imagePath };
+  }
+
+  const resolvedPath = resolveLocalPath(imagePath, baseDir);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Image not found: ${resolvedPath}`);
+  }
+
+  const fileBuffer = fs.readFileSync(resolvedPath);
+  if (fileBuffer.length === 0) {
+    throw new Error(`Local image is empty: ${resolvedPath}`);
+  }
+
+  let filename = path.basename(resolvedPath);
+  let fileExt = path.extname(filename).toLowerCase();
+  const mimeTypes: Record<string, string> = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".tiff": "image/tiff",
+    ".tif": "image/tiff",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+  };
+  let contentType = mimeTypes[fileExt] || "image/jpeg";
+
+  const detected = detectImageFormatFromBuffer(fileBuffer);
+  if (detected && detected.contentType !== contentType) {
+    contentType = detected.contentType;
+    fileExt = detected.fileExt;
+    filename = `${path.basename(filename, path.extname(filename))}${detected.fileExt}`;
+  }
+
+  return {
+    buffer: fileBuffer,
+    filename,
+    contentType,
+    fileExt,
+    fileSize: fileBuffer.length,
+  };
+}
+
+async function stageAsset(
+  imagePath: string,
+  baseDir: string,
+  imagesDir: string,
+  usedNames: Set<string>,
+  uploadType: "body" | "material",
+): Promise<StagedAssetRef> {
+  const asset = await loadUploadAsset(imagePath, baseDir);
+  if ("remoteUrl" in asset) {
+    return { remote_url: asset.remoteUrl };
+  }
+
+  let staged = asset;
+  if (uploadType === "body" && needsWechatBodyImageProcessing(asset)) {
+    const prepared = await prepareWechatBodyImageUpload(asset);
+    staged = {
+      ...asset,
+      buffer: prepared.buffer,
+      filename: prepared.filename,
+      contentType: prepared.contentType,
+      fileExt: path.extname(prepared.filename).toLowerCase(),
+      fileSize: prepared.buffer.length,
+    };
+  }
+
+  const filename = uniqueName(staged.filename, usedNames);
+  fs.writeFileSync(path.join(imagesDir, filename), staged.buffer);
+  return { filename, content_type: staged.contentType };
+}
+
+function collectHtmlImageSources(html: string): string[] {
+  const imgRegex = /<img[^>]*\ssrc=["']([^"']+)["'][^>]*>/gi;
+  const sources: string[] = [];
+  for (const match of html.matchAll(imgRegex)) {
+    const src = match[1];
+    if (src && !sources.includes(src)) sources.push(src);
+  }
+  return sources;
+}
+
+function runChecked(command: string, args: string[], options?: { capture?: boolean }): string {
+  const result = spawnSync(command, args, {
+    encoding: "utf-8",
+    stdio: options?.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+    throw new Error(`${command} ${args.join(" ")} failed${stderr ? `: ${stderr}` : ""}`);
+  }
+  return typeof result.stdout === "string" ? result.stdout : "";
+}
+
+function runBestEffort(command: string, args: string[]): void {
+  spawnSync(command, args, { stdio: "ignore" });
+}
+
+export async function publishRemoteDraft(options: RemotePublishOptions): Promise<RemotePublishResult> {
+  const remote = normalizeRemoteConfig(options.remote);
+  if (!options.appId || !options.appSecret) {
+    throw new Error("Remote publish requires WeChat API credentials.");
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "baoyu-wechat-remote-"));
+  const imagesDir = path.join(tmpDir, "images");
+  fs.mkdirSync(imagesDir, { recursive: true });
+
+  const usedNames = new Set<string>();
+  const collectNewsCoverFallback = options.articleType === "news" && !options.coverPath;
+
+  try {
+    const htmlImages: StagedHtmlImage[] = [];
+    for (const src of collectHtmlImageSources(options.html)) {
+      if (src.startsWith("https://mmbiz.qpic.cn")) {
+        htmlImages.push({ src });
+        continue;
+      }
+
+      const shouldUploadMaterial = options.articleType === "newspic" || collectNewsCoverFallback;
+      htmlImages.push({
+        src,
+        body: await stageAsset(src, options.baseDir, imagesDir, usedNames, "body"),
+        material: shouldUploadMaterial
+          ? await stageAsset(src, options.baseDir, imagesDir, usedNames, "material")
+          : undefined,
+      });
+    }
+
+    const placeholderImages: StagedPlaceholderImage[] = [];
+    for (const image of options.contentImages || []) {
+      if (!options.html.includes(image.placeholder)) continue;
+
+      const imagePath = image.localPath || image.originalPath;
+      const shouldUploadMaterial = options.articleType === "newspic" || collectNewsCoverFallback;
+      placeholderImages.push({
+        placeholder: image.placeholder,
+        body: await stageAsset(imagePath, options.baseDir, imagesDir, usedNames, "body"),
+        material: shouldUploadMaterial
+          ? await stageAsset(imagePath, options.baseDir, imagesDir, usedNames, "material")
+          : undefined,
+      });
+    }
+
+    const cover = options.coverPath
+      ? await stageAsset(options.coverPath, options.baseDir, imagesDir, usedNames, "material")
+      : undefined;
+
+    fs.writeFileSync(path.join(tmpDir, "payload.json"), JSON.stringify({
+      title: options.title,
+      author: options.author || "",
+      digest: options.digest || "",
+      html: options.html,
+      article_type: options.articleType,
+      need_open_comment: options.needOpenComment,
+      only_fans_can_comment: options.onlyFansCanComment,
+      html_images: htmlImages,
+      placeholder_images: placeholderImages,
+      cover,
+      collect_news_cover_fallback: collectNewsCoverFallback,
+    }, null, 2));
+
+    const wechatPath = path.join(tmpDir, "wechat.json");
+    fs.writeFileSync(wechatPath, JSON.stringify({
+      app_id: options.appId,
+      app_secret: options.appSecret,
+    }, null, 2));
+    fs.chmodSync(wechatPath, 0o600);
+
+    const publisherPath = path.join(tmpDir, "remote_publisher.py");
+    fs.writeFileSync(publisherPath, REMOTE_PUBLISHER);
+    fs.chmodSync(publisherPath, 0o700);
+
+    const remoteTarget = `${remote.user}@${remote.host}`;
+    const remoteRunDir = `${remote.workdir.replace(/\/+$/, "")}/${randomUUID()}`;
+    const sshBase = ["-p", String(remote.port), ...remote.sshOptions, remoteTarget];
+    const scpBase = ["-P", String(remote.port), ...remote.sshOptions];
+
+    runChecked("ssh", [...sshBase, `rm -rf ${shQuote(remoteRunDir)} && mkdir -p ${shQuote(remoteRunDir)}`]);
+    runChecked("scp", [...scpBase, "-r", `${tmpDir}/.`, `${remoteTarget}:${remoteRunDir}/`]);
+
+    try {
+      const stdout = runChecked(
+        "ssh",
+        [...sshBase, `cd ${shQuote(remoteRunDir)} && python3 remote_publisher.py`],
+        { capture: true },
+      );
+      const lastLine = stdout.trim().split(/\r?\n/).filter(Boolean).at(-1);
+      if (!lastLine) throw new Error("Remote publisher returned no output.");
+      const result = JSON.parse(lastLine) as {
+        media_id: string;
+        title: string;
+        body_images: number;
+        image_media_ids: number;
+      };
+      return {
+        mediaId: result.media_id,
+        title: result.title,
+        bodyImages: result.body_images,
+        imageMediaIds: result.image_media_ids,
+      };
+    } finally {
+      if (remote.cleanup) {
+        runBestEffort("ssh", [...sshBase, `rm -rf ${shQuote(remoteRunDir)}`]);
+      }
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.ts
@@ -1,7 +1,10 @@
+import dns from "node:dns/promises";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
 
 import {
@@ -17,7 +20,11 @@ export interface RemotePublishConfig {
   port?: number;
   workdir?: string;
   cleanup?: boolean;
-  sshOptions?: string[];
+  identityFile?: string;
+  knownHostsFile?: string;
+  strictHostKeyChecking?: "yes" | "no" | "accept-new";
+  connectTimeout?: number;
+  proxyJump?: string;
 }
 
 interface RemoteImageInfo {
@@ -50,9 +57,8 @@ export interface RemotePublishResult {
 }
 
 interface StagedAssetRef {
-  filename?: string;
-  content_type?: string;
-  remote_url?: string;
+  filename: string;
+  content_type: string;
 }
 
 interface StagedHtmlImage {
@@ -67,199 +73,19 @@ interface StagedPlaceholderImage {
   material?: StagedAssetRef;
 }
 
-const REMOTE_PUBLISHER = String.raw`#!/usr/bin/env python3
-import json
-import mimetypes
-import urllib.parse
-import urllib.request
-from pathlib import Path
-from uuid import uuid4
-
-API = "https://api.weixin.qq.com"
-ROOT = Path(__file__).resolve().parent
-
-
-def request_json(url, data=None, headers=None):
-    body = None
-    if data is not None:
-        body = json.dumps(data, ensure_ascii=False).encode("utf-8")
-        headers = {"Content-Type": "application/json; charset=utf-8", **(headers or {})}
-    req = urllib.request.Request(url, data=body, headers=headers or {})
-    with urllib.request.urlopen(req, timeout=60) as resp:
-        raw = resp.read().decode("utf-8")
-    obj = json.loads(raw)
-    if obj.get("errcode") not in (None, 0):
-        raise RuntimeError(f"WeChat API error {obj.get('errcode')}: {obj.get('errmsg')}")
-    return obj
-
-
-def load_asset(asset):
-    if asset.get("remote_url"):
-        req = urllib.request.Request(asset["remote_url"], headers={"User-Agent": "baoyu-post-to-wechat/remote"})
-        with urllib.request.urlopen(req, timeout=120) as resp:
-            data = resp.read()
-            content_type = resp.headers.get("content-type") or asset.get("content_type") or "image/jpeg"
-        filename = Path(urllib.parse.urlparse(asset["remote_url"]).path).name or f"remote-{uuid4().hex}.jpg"
-        return data, filename, content_type
-
-    file_path = ROOT / "images" / asset["filename"]
-    return (
-        file_path.read_bytes(),
-        asset["filename"],
-        asset.get("content_type") or mimetypes.guess_type(file_path.name)[0] or "application/octet-stream",
-    )
-
-
-def multipart_upload(url, asset):
-    data, filename, content_type = load_asset(asset)
-    boundary = f"----baoyu-wechat-{uuid4().hex}"
-    body = b"".join([
-        f"--{boundary}\r\n".encode(),
-        f'Content-Disposition: form-data; name="media"; filename="{filename}"\r\n'.encode(),
-        f"Content-Type: {content_type}\r\n\r\n".encode(),
-        data,
-        b"\r\n",
-        f"--{boundary}--\r\n".encode(),
-    ])
-    req = urllib.request.Request(
-        url,
-        data=body,
-        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
-    )
-    with urllib.request.urlopen(req, timeout=120) as resp:
-        raw = resp.read().decode("utf-8")
-    obj = json.loads(raw)
-    if obj.get("errcode") not in (None, 0):
-        raise RuntimeError(f"WeChat upload error {obj.get('errcode')}: {obj.get('errmsg')}")
-    return obj
-
-
-def get_token(appid, secret):
-    query = urllib.parse.urlencode({
-        "grant_type": "client_credential",
-        "appid": appid,
-        "secret": secret,
-    })
-    return request_json(f"{API}/cgi-bin/token?{query}")["access_token"]
-
-
-def upload_body_image(token, asset):
-    obj = multipart_upload(
-        f"{API}/cgi-bin/media/uploadimg?access_token={urllib.parse.quote(token)}",
-        asset,
-    )
-    url = obj["url"]
-    return "https://" + url[len("http://"):] if url.startswith("http://") else url
-
-
-def upload_material(token, asset):
-    obj = multipart_upload(
-        f"{API}/cgi-bin/material/add_material?access_token={urllib.parse.quote(token)}&type=image",
-        asset,
-    )
-    return obj["media_id"]
-
-
-def replace_all_placeholders(html, placeholder, replacement):
-    return html.replace(placeholder, replacement)
-
-
-def publish_to_draft(token, payload, content, thumb_media_id, image_media_ids):
-    article_type = payload["article_type"]
-    article = {
-        "article_type": article_type,
-        "title": payload["title"],
-        "content": content,
-        "need_open_comment": payload.get("need_open_comment", 1),
-        "only_fans_can_comment": payload.get("only_fans_can_comment", 0),
-    }
-    if payload.get("author"):
-        article["author"] = payload["author"]
-
-    if article_type == "newspic":
-        article["image_info"] = {
-            "image_list": [{"image_media_id": item} for item in image_media_ids],
-        }
-    else:
-        article["thumb_media_id"] = thumb_media_id
-        if payload.get("digest"):
-            article["digest"] = payload["digest"]
-
-    return request_json(
-        f"{API}/cgi-bin/draft/add?access_token={urllib.parse.quote(token)}",
-        {"articles": [article]},
-    )
-
-
-def main():
-    payload = json.loads((ROOT / "payload.json").read_text(encoding="utf-8"))
-    secrets = json.loads((ROOT / "wechat.json").read_text(encoding="utf-8"))
-    token = get_token(secrets["app_id"], secrets["app_secret"])
-
-    html = payload["html"]
-    image_media_ids = []
-    thumb_media_id = None
-    body_uploads = 0
-
-    for item in payload.get("html_images", []):
-        src = item["src"]
-        if src.startswith("https://mmbiz.qpic.cn"):
-            if payload.get("collect_news_cover_fallback") and not thumb_media_id:
-                thumb_media_id = upload_material(token, {"remote_url": src, "content_type": "image/jpeg"})
-            continue
-
-        body_asset = item.get("body")
-        if body_asset:
-            image_url = upload_body_image(token, body_asset)
-            html = html.replace(src, image_url)
-            body_uploads += 1
-
-        if item.get("material"):
-            media_id = upload_material(token, item["material"])
-            if payload["article_type"] == "newspic":
-                image_media_ids.append(media_id)
-            if payload.get("collect_news_cover_fallback") and not thumb_media_id:
-                thumb_media_id = media_id
-
-    for item in payload.get("placeholder_images", []):
-        image_url = upload_body_image(token, item["body"])
-        replacement = f'<img src="{image_url}" style="display: block; width: 100%; margin: 1.5em auto;">'
-        html = replace_all_placeholders(html, item["placeholder"], replacement)
-        body_uploads += 1
-
-        if item.get("material"):
-            media_id = upload_material(token, item["material"])
-            if payload["article_type"] == "newspic":
-                image_media_ids.append(media_id)
-            if payload.get("collect_news_cover_fallback") and not thumb_media_id:
-                thumb_media_id = media_id
-
-    if payload.get("cover"):
-        thumb_media_id = upload_material(token, payload["cover"])
-
-    if payload["article_type"] == "news" and not thumb_media_id:
-        raise RuntimeError("news article requires thumb_media_id")
-    if payload["article_type"] == "newspic" and not image_media_ids:
-        raise RuntimeError("newspic requires at least one image_media_id")
-
-    result = publish_to_draft(token, payload, html, thumb_media_id, image_media_ids)
-    print(json.dumps({
-        "media_id": result.get("media_id"),
-        "title": payload["title"],
-        "body_images": body_uploads,
-        "image_media_ids": len(image_media_ids),
-    }, ensure_ascii=False))
-
-
-if __name__ == "__main__":
-    main()
-`;
+interface NormalizedRemoteConfig extends Required<Pick<RemotePublishConfig, "host" | "user" | "port" | "workdir" | "cleanup">> {
+  identityFile?: string;
+  knownHostsFile?: string;
+  strictHostKeyChecking?: "yes" | "no" | "accept-new";
+  connectTimeout?: number;
+  proxyJump?: string;
+}
 
 function shQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function normalizeRemoteConfig(remote: RemotePublishConfig): Required<RemotePublishConfig> {
+function normalizeRemoteConfig(remote: RemotePublishConfig): NormalizedRemoteConfig {
   const host = remote.host?.trim();
   if (!host) throw new Error("Remote publish requires remote_publish_host.");
 
@@ -269,8 +95,22 @@ function normalizeRemoteConfig(remote: RemotePublishConfig): Required<RemotePubl
     port: remote.port || 22,
     workdir: remote.workdir?.trim() || "/tmp/baoyu-wechat-remote-publish",
     cleanup: remote.cleanup ?? true,
-    sshOptions: remote.sshOptions || [],
+    identityFile: remote.identityFile?.trim() || undefined,
+    knownHostsFile: remote.knownHostsFile?.trim() || undefined,
+    strictHostKeyChecking: remote.strictHostKeyChecking,
+    connectTimeout: remote.connectTimeout,
+    proxyJump: remote.proxyJump?.trim() || undefined,
   };
+}
+
+function buildSshOptions(remote: NormalizedRemoteConfig): string[] {
+  const options: string[] = [];
+  if (remote.identityFile) options.push("-i", remote.identityFile);
+  if (remote.knownHostsFile) options.push("-o", `UserKnownHostsFile=${remote.knownHostsFile}`);
+  if (remote.strictHostKeyChecking) options.push("-o", `StrictHostKeyChecking=${remote.strictHostKeyChecking}`);
+  if (remote.connectTimeout) options.push("-o", `ConnectTimeout=${remote.connectTimeout}`);
+  if (remote.proxyJump) options.push("-J", remote.proxyJump);
+  return options;
 }
 
 function uniqueName(name: string, used: Set<string>): string {
@@ -295,36 +135,139 @@ function resolveLocalPath(imagePath: string, baseDir: string): string {
   return path.isAbsolute(imagePath) ? imagePath : path.resolve(baseDir, imagePath);
 }
 
-async function loadUploadAsset(imagePath: string, baseDir: string): Promise<WechatUploadAsset | { remoteUrl: string }> {
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split(".").map(part => Number.parseInt(part, 10));
+  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) return true;
+  const [a, b, c] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
+  );
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+  if (normalized.includes(".")) {
+    const mapped = normalized.match(/(?:::ffff:)?(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped) return isPrivateIpv4(mapped[1]!);
+  }
+  return (
+    normalized === "::1" ||
+    normalized === "::" ||
+    normalized.startsWith("fe80:") ||
+    normalized.startsWith("fc") ||
+    normalized.startsWith("fd")
+  );
+}
+
+function isPrivateAddress(address: string): boolean {
+  const family = net.isIP(address);
+  if (family === 4) return isPrivateIpv4(address);
+  if (family === 6) return isPrivateIpv6(address);
+  return true;
+}
+
+async function assertPublicHttpsUrl(rawUrl: string): Promise<URL> {
+  const parsed = new URL(rawUrl);
+  if (parsed.protocol !== "https:") {
+    throw new Error(`Remote images must use https URLs: ${rawUrl}`);
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (hostname === "localhost" || hostname.endsWith(".localhost") || hostname.endsWith(".local")) {
+    throw new Error(`Remote image host is not allowed: ${hostname}`);
+  }
+
+  if (isPrivateAddress(hostname)) {
+    throw new Error(`Remote image host resolves to a private address: ${hostname}`);
+  }
+
+  const addresses = await dns.lookup(hostname, { all: true });
+  if (addresses.length === 0 || addresses.some(address => isPrivateAddress(address.address))) {
+    throw new Error(`Remote image host resolves to a private address: ${hostname}`);
+  }
+
+  return parsed;
+}
+
+async function fetchRemoteImage(url: string, redirects = 0): Promise<{ buffer: Buffer; filename: string; contentType: string }> {
+  if (redirects > 5) throw new Error(`Too many redirects while downloading image: ${url}`);
+  const parsed = await assertPublicHttpsUrl(url);
+  const response = await fetch(parsed, {
+    redirect: "manual",
+    headers: { "User-Agent": "baoyu-post-to-wechat/remote-stager" },
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  if ([301, 302, 303, 307, 308].includes(response.status)) {
+    const location = response.headers.get("location");
+    if (!location) throw new Error(`Image redirect without Location: ${url}`);
+    return await fetchRemoteImage(new URL(location, parsed).toString(), redirects + 1);
+  }
+
+  if (!response.ok) throw new Error(`Failed to download image: ${url} (${response.status})`);
+
+  const contentType = response.headers.get("content-type") || "image/jpeg";
+  if (!contentType.toLowerCase().startsWith("image/")) {
+    throw new Error(`Remote URL did not return an image content type: ${url} (${contentType})`);
+  }
+
+  const finalUrl = await assertPublicHttpsUrl(response.url || parsed.toString());
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (buffer.length === 0) throw new Error(`Remote image is empty: ${url}`);
+  const filename = path.basename(finalUrl.pathname) || `remote-${randomUUID()}.jpg`;
+  return { buffer, filename, contentType };
+}
+
+async function loadUploadAsset(imagePath: string, baseDir: string): Promise<WechatUploadAsset> {
+  let fileBuffer: Buffer;
+  let filename: string;
+  let fileExt = "";
+  let contentType = "image/jpeg";
+
   if (imagePath.startsWith("http://") || imagePath.startsWith("https://")) {
-    return { remoteUrl: imagePath };
-  }
+    const downloaded = await fetchRemoteImage(imagePath);
+    fileBuffer = downloaded.buffer;
+    filename = downloaded.filename;
+    fileExt = path.extname(filename).toLowerCase();
+    contentType = downloaded.contentType;
+  } else {
+    const resolvedPath = resolveLocalPath(imagePath, baseDir);
+    if (!fs.existsSync(resolvedPath)) {
+      throw new Error(`Image not found: ${resolvedPath}`);
+    }
 
-  const resolvedPath = resolveLocalPath(imagePath, baseDir);
-  if (!fs.existsSync(resolvedPath)) {
-    throw new Error(`Image not found: ${resolvedPath}`);
-  }
+    fileBuffer = fs.readFileSync(resolvedPath);
+    if (fileBuffer.length === 0) {
+      throw new Error(`Local image is empty: ${resolvedPath}`);
+    }
 
-  const fileBuffer = fs.readFileSync(resolvedPath);
-  if (fileBuffer.length === 0) {
-    throw new Error(`Local image is empty: ${resolvedPath}`);
+    filename = path.basename(resolvedPath);
+    fileExt = path.extname(filename).toLowerCase();
+    const mimeTypes: Record<string, string> = {
+      ".jpg": "image/jpeg",
+      ".jpeg": "image/jpeg",
+      ".png": "image/png",
+      ".gif": "image/gif",
+      ".webp": "image/webp",
+      ".bmp": "image/bmp",
+      ".tiff": "image/tiff",
+      ".tif": "image/tiff",
+      ".svg": "image/svg+xml",
+      ".ico": "image/x-icon",
+    };
+    contentType = mimeTypes[fileExt] || "image/jpeg";
   }
-
-  let filename = path.basename(resolvedPath);
-  let fileExt = path.extname(filename).toLowerCase();
-  const mimeTypes: Record<string, string> = {
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".png": "image/png",
-    ".gif": "image/gif",
-    ".webp": "image/webp",
-    ".bmp": "image/bmp",
-    ".tiff": "image/tiff",
-    ".tif": "image/tiff",
-    ".svg": "image/svg+xml",
-    ".ico": "image/x-icon",
-  };
-  let contentType = mimeTypes[fileExt] || "image/jpeg";
 
   const detected = detectImageFormatFromBuffer(fileBuffer);
   if (detected && detected.contentType !== contentType) {
@@ -350,9 +293,6 @@ async function stageAsset(
   uploadType: "body" | "material",
 ): Promise<StagedAssetRef> {
   const asset = await loadUploadAsset(imagePath, baseDir);
-  if ("remoteUrl" in asset) {
-    return { remote_url: asset.remoteUrl };
-  }
 
   let staged = asset;
   if (uploadType === "body" && needsWechatBodyImageProcessing(asset)) {
@@ -382,10 +322,11 @@ function collectHtmlImageSources(html: string): string[] {
   return sources;
 }
 
-function runChecked(command: string, args: string[], options?: { capture?: boolean }): string {
+function runChecked(command: string, args: string[], options?: { capture?: boolean; input?: string }): string {
   const result = spawnSync(command, args, {
     encoding: "utf-8",
-    stdio: options?.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    input: options?.input,
+    stdio: options?.capture ? ["pipe", "pipe", "pipe"] : options?.input ? ["pipe", "inherit", "inherit"] : "inherit",
   });
 
   if (result.error) {
@@ -410,7 +351,7 @@ export async function publishRemoteDraft(options: RemotePublishOptions): Promise
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "baoyu-wechat-remote-"));
   const imagesDir = path.join(tmpDir, "images");
-  fs.mkdirSync(imagesDir, { recursive: true });
+  fs.mkdirSync(imagesDir, { recursive: true, mode: 0o700 });
 
   const usedNames = new Set<string>();
   const collectNewsCoverFallback = options.articleType === "news" && !options.coverPath;
@@ -418,15 +359,13 @@ export async function publishRemoteDraft(options: RemotePublishOptions): Promise
   try {
     const htmlImages: StagedHtmlImage[] = [];
     for (const src of collectHtmlImageSources(options.html)) {
-      if (src.startsWith("https://mmbiz.qpic.cn")) {
-        htmlImages.push({ src });
-        continue;
-      }
-
       const shouldUploadMaterial = options.articleType === "newspic" || collectNewsCoverFallback;
+      const shouldUploadBody = !src.startsWith("https://mmbiz.qpic.cn");
       htmlImages.push({
         src,
-        body: await stageAsset(src, options.baseDir, imagesDir, usedNames, "body"),
+        body: shouldUploadBody
+          ? await stageAsset(src, options.baseDir, imagesDir, usedNames, "body")
+          : undefined,
         material: shouldUploadMaterial
           ? await stageAsset(src, options.baseDir, imagesDir, usedNames, "material")
           : undefined,
@@ -466,30 +405,31 @@ export async function publishRemoteDraft(options: RemotePublishOptions): Promise
       collect_news_cover_fallback: collectNewsCoverFallback,
     }, null, 2));
 
-    const wechatPath = path.join(tmpDir, "wechat.json");
-    fs.writeFileSync(wechatPath, JSON.stringify({
-      app_id: options.appId,
-      app_secret: options.appSecret,
-    }, null, 2));
-    fs.chmodSync(wechatPath, 0o600);
-
+    const __filename = fileURLToPath(import.meta.url);
+    const publisherSource = path.join(path.dirname(__filename), "remote_publisher.py");
     const publisherPath = path.join(tmpDir, "remote_publisher.py");
-    fs.writeFileSync(publisherPath, REMOTE_PUBLISHER);
+    fs.copyFileSync(publisherSource, publisherPath);
     fs.chmodSync(publisherPath, 0o700);
 
     const remoteTarget = `${remote.user}@${remote.host}`;
     const remoteRunDir = `${remote.workdir.replace(/\/+$/, "")}/${randomUUID()}`;
-    const sshBase = ["-p", String(remote.port), ...remote.sshOptions, remoteTarget];
-    const scpBase = ["-P", String(remote.port), ...remote.sshOptions];
-
-    runChecked("ssh", [...sshBase, `rm -rf ${shQuote(remoteRunDir)} && mkdir -p ${shQuote(remoteRunDir)}`]);
-    runChecked("scp", [...scpBase, "-r", `${tmpDir}/.`, `${remoteTarget}:${remoteRunDir}/`]);
+    const sshOptions = buildSshOptions(remote);
+    const sshBase = ["-p", String(remote.port), ...sshOptions, remoteTarget];
+    const scpBase = ["-P", String(remote.port), ...sshOptions];
+    let remoteCreated = false;
 
     try {
+      runChecked("ssh", [...sshBase, `umask 077 && rm -rf ${shQuote(remoteRunDir)} && mkdir -p ${shQuote(remoteRunDir)} && chmod 700 ${shQuote(remoteRunDir)}`]);
+      remoteCreated = true;
+      runChecked("scp", [...scpBase, "-r", `${tmpDir}/.`, `${remoteTarget}:${remoteRunDir}/`]);
+
       const stdout = runChecked(
         "ssh",
         [...sshBase, `cd ${shQuote(remoteRunDir)} && python3 remote_publisher.py`],
-        { capture: true },
+        {
+          capture: true,
+          input: JSON.stringify({ app_id: options.appId, app_secret: options.appSecret }),
+        },
       );
       const lastLine = stdout.trim().split(/\r?\n/).filter(Boolean).at(-1);
       if (!lastLine) throw new Error("Remote publisher returned no output.");
@@ -506,7 +446,7 @@ export async function publishRemoteDraft(options: RemotePublishOptions): Promise
         imageMediaIds: result.image_media_ids,
       };
     } finally {
-      if (remote.cleanup) {
+      if (remote.cleanup && remoteCreated) {
         runBestEffort("ssh", [...sshBase, `rm -rf ${shQuote(remoteRunDir)}`]);
       }
     }

--- a/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-remote-publish.ts
@@ -1,5 +1,8 @@
+import type { LookupAddress } from "node:dns";
 import dns from "node:dns/promises";
 import fs from "node:fs";
+import type { IncomingHttpHeaders } from "node:http";
+import * as https from "node:https";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -80,6 +83,14 @@ interface NormalizedRemoteConfig extends Required<Pick<RemotePublishConfig, "hos
   connectTimeout?: number;
   proxyJump?: string;
 }
+
+type LookupAll = (hostname: string) => Promise<LookupAddress[]>;
+
+interface ResolvedHttpsUrl {
+  url: URL;
+  address: LookupAddress;
+}
+
 
 function shQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
@@ -170,14 +181,28 @@ function isPrivateIpv6(ip: string): boolean {
   );
 }
 
-function isPrivateAddress(address: string): boolean {
-  const family = net.isIP(address);
-  if (family === 4) return isPrivateIpv4(address);
-  if (family === 6) return isPrivateIpv6(address);
-  return true;
+function normalizeIpLiteral(hostname: string): string {
+  return hostname.startsWith("[") && hostname.endsWith("]")
+    ? hostname.slice(1, -1)
+    : hostname;
 }
 
-async function assertPublicHttpsUrl(rawUrl: string): Promise<URL> {
+export function isPrivateAddress(address: string): boolean {
+  const normalized = normalizeIpLiteral(address);
+  const family = net.isIP(normalized);
+  if (family === 4) return isPrivateIpv4(normalized);
+  if (family === 6) return isPrivateIpv6(normalized);
+  return false;
+}
+
+async function defaultLookupAll(hostname: string): Promise<LookupAddress[]> {
+  return await dns.lookup(hostname, { all: true });
+}
+
+export async function resolvePublicHttpsUrl(
+  rawUrl: string,
+  lookupAll: LookupAll = defaultLookupAll,
+): Promise<ResolvedHttpsUrl> {
   const parsed = new URL(rawUrl);
   if (parsed.protocol !== "https:") {
     throw new Error(`Remote images must use https URLs: ${rawUrl}`);
@@ -188,45 +213,74 @@ async function assertPublicHttpsUrl(rawUrl: string): Promise<URL> {
     throw new Error(`Remote image host is not allowed: ${hostname}`);
   }
 
-  if (isPrivateAddress(hostname)) {
-    throw new Error(`Remote image host resolves to a private address: ${hostname}`);
+  const literalAddress = normalizeIpLiteral(hostname);
+  const literalFamily = net.isIP(literalAddress);
+  if (literalFamily !== 0) {
+    if (isPrivateAddress(literalAddress)) {
+      throw new Error(`Remote image host resolves to a private address: ${hostname}`);
+    }
+    return { url: parsed, address: { address: literalAddress, family: literalFamily } };
   }
 
-  const addresses = await dns.lookup(hostname, { all: true });
+  const addresses = await lookupAll(hostname);
   if (addresses.length === 0 || addresses.some(address => isPrivateAddress(address.address))) {
     throw new Error(`Remote image host resolves to a private address: ${hostname}`);
   }
 
-  return parsed;
+  return { url: parsed, address: addresses[0]! };
+}
+
+function readHttpsImage(resolved: ResolvedHttpsUrl): Promise<{ statusCode: number; headers: IncomingHttpHeaders; buffer: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(resolved.url, {
+      method: "GET",
+      headers: { "User-Agent": "baoyu-post-to-wechat/remote-stager" },
+      timeout: 60_000,
+      lookup: (_hostname, _options, callback) => {
+        callback(null, resolved.address.address, resolved.address.family);
+      },
+    }, (res) => {
+      const statusCode = res.statusCode || 0;
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+      res.on("end", () => {
+        resolve({ statusCode, headers: res.headers, buffer: Buffer.concat(chunks) });
+      });
+    });
+
+    req.on("timeout", () => {
+      req.destroy(new Error(`Timed out while downloading image: ${resolved.url.toString()}`));
+    });
+    req.on("error", reject);
+    req.end();
+  });
 }
 
 async function fetchRemoteImage(url: string, redirects = 0): Promise<{ buffer: Buffer; filename: string; contentType: string }> {
   if (redirects > 5) throw new Error(`Too many redirects while downloading image: ${url}`);
-  const parsed = await assertPublicHttpsUrl(url);
-  const response = await fetch(parsed, {
-    redirect: "manual",
-    headers: { "User-Agent": "baoyu-post-to-wechat/remote-stager" },
-    signal: AbortSignal.timeout(60_000),
-  });
+  const resolved = await resolvePublicHttpsUrl(url);
+  const response = await readHttpsImage(resolved);
 
-  if ([301, 302, 303, 307, 308].includes(response.status)) {
-    const location = response.headers.get("location");
+  if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+    const location = response.headers.location;
     if (!location) throw new Error(`Image redirect without Location: ${url}`);
-    return await fetchRemoteImage(new URL(location, parsed).toString(), redirects + 1);
+    return await fetchRemoteImage(new URL(String(location), resolved.url).toString(), redirects + 1);
   }
 
-  if (!response.ok) throw new Error(`Failed to download image: ${url} (${response.status})`);
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw new Error(`Failed to download image: ${url} (${response.statusCode})`);
+  }
 
-  const contentType = response.headers.get("content-type") || "image/jpeg";
+  const contentType = String(response.headers["content-type"] || "image/jpeg");
   if (!contentType.toLowerCase().startsWith("image/")) {
     throw new Error(`Remote URL did not return an image content type: ${url} (${contentType})`);
   }
 
-  const finalUrl = await assertPublicHttpsUrl(response.url || parsed.toString());
-  const buffer = Buffer.from(await response.arrayBuffer());
-  if (buffer.length === 0) throw new Error(`Remote image is empty: ${url}`);
-  const filename = path.basename(finalUrl.pathname) || `remote-${randomUUID()}.jpg`;
-  return { buffer, filename, contentType };
+  if (response.buffer.length === 0) throw new Error(`Remote image is empty: ${url}`);
+  const filename = path.basename(resolved.url.pathname) || `remote-${randomUUID()}.jpg`;
+  return { buffer: response.buffer, filename, contentType };
 }
 
 async function loadUploadAsset(imagePath: string, baseDir: string): Promise<WechatUploadAsset> {


### PR DESCRIPTION
Adds remote API publishing for baoyu-post-to-wechat.

- Converts content locally
- Uploads temporary payload to a configured remote server via SSH/SCP
- Calls WeChat API from the remote server IP
- Cleans remote temp files by default
- Documents remote_publish_* EXTEND.md options
- Includes tests for remote publish config parsing

Verified by creating a WeChat draft through remote-api.