### PR TITLE
fix: improve newspic plain text conversion for WeChat API

### DIFF
--- a/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
@@ -364,10 +364,12 @@ async function publishToDraft(
     if (!options.imageMediaIds || options.imageMediaIds.length === 0) {
       throw new Error("newspic requires at least one image");
     }
+    // newspic 的 content 应该是纯文本，去掉 HTML 标签
+    const plainContent = options.content.replace(/<[^>]+>/g, "").trim();
     article = {
       article_type: "newspic",
       title: options.title,
-      content: options.content,
+      content: plainContent,
       need_open_comment: noc,
       only_fans_can_comment: ofcc,
       image_info: {

--- a/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
@@ -83,6 +83,60 @@ function toHttpsUrl(url: string | undefined): string {
   return url.startsWith("http://") ? url.replace(/^http:\/\//i, "https://") : url;
 }
 
+function htmlToPlainText(html: string): string {
+  if (!html) return "";
+
+  let text = html;
+
+  // 1. 将 <br>, <br/>, <br /> 替换为换行符
+  text = text.replace(/<br\s*\/?>/gi, "\n");
+
+  // 2. 将 </p>, </div>, </h1>, </h2>, </h3>, </h4>, </h5>, </h6>, </li> 替换为换行符
+  text = text.replace(/<\/(?:p|div|h[1-6]|li|tr|td|th)>/gi, "\n");
+
+  // 3. 去掉所有剩余的 HTML 标签
+  text = text.replace(/<[^>]+>/g, "");
+
+  // 4. 解码 HTML 实体
+  const entityMap: Record<string, string> = {
+    "&nbsp;": " ",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&amp;": "&",
+    "&quot;": '"',
+    "&#39;": "'",
+    "&apos;": "'",
+    "&mdash;": "—",
+    "&ndash;": "–",
+    "&hellip;": "…",
+    "&ldquo;": """,
+    "&rdquo;": """,
+    "&lsquo;": "'",
+    "&rsquo;": "'",
+  };
+  text = text.replace(/&(?:[a-zA-Z]+|#\d+);/g, (entity) => {
+    if (entityMap[entity]) return entityMap[entity];
+    // 处理数字实体，如 &#123;
+    const numMatch = entity.match(/&#(\d+);/);
+    if (numMatch) {
+      return String.fromCharCode(Number.parseInt(numMatch[1]!, 10));
+    }
+    return entity;
+  });
+
+  // 5. 合并多个连续空白字符（空格、制表符、换行）为一个空格
+  text = text.replace(/[ \t]+/g, " ");
+
+  // 6. 合并多个连续换行为一个换行
+  text = text.replace(/\n{3,}/g, "\n\n");
+
+  // 7. 去掉行首行尾空白
+  text = text.split("\n").map(line => line.trim()).join("\n");
+
+  // 8. 最终 trim
+  return text.trim();
+}
+
 async function loadUploadAsset(
   imagePath: string,
   baseDir?: string,
@@ -364,8 +418,11 @@ async function publishToDraft(
     if (!options.imageMediaIds || options.imageMediaIds.length === 0) {
       throw new Error("newspic requires at least one image");
     }
-    // newspic 的 content 应该是纯文本，去掉 HTML 标签
-    const plainContent = options.content.replace(/<[^>]+>/g, "").trim();
+    // newspic 的 content 应该是纯文本，需要：
+    // 1. 去掉 HTML 标签
+    // 2. 解码 HTML 实体（&nbsp;、&lt; 等）
+    // 3. 合并多余空白字符
+    const plainContent = htmlToPlainText(options.content);
     article = {
       article_type: "newspic",
       title: options.title,


### PR DESCRIPTION
## Description

This PR improves the plain text conversion for `newspic` (image-text) article type to comply with WeChat API requirements.

Fixes #163

## Problem

When publishing `newspic` articles, the `content` field was passing HTML content instead of plain text. This caused error 45166 (invalid content) especially when publishing with multiple images, as the HTML content became too long.

The initial fix (commit `2e2587a`) used a simple regex `replace(/<[^>]+>/g, "")` to strip HTML tags, but it had several issues:

1. **HTML entities not decoded** - `&nbsp;`, `&lt;`, `&gt;`, `&amp;`, etc. remained in text
2. **No line breaks preserved** - Block-level tags didn't produce line breaks
3. **Excess whitespace not collapsed** - Multiple spaces and newlines were preserved

## Solution

Introduced a dedicated `htmlToPlainText()` function that:

- Converts `<br>` and block-level closing tags to line breaks
- Strips all remaining HTML tags
- Decodes common HTML entities (including numeric entities like `&#123;`)
- Collapses consecutive whitespace into single spaces
- Trims whitespace from each line

## Changes

**File:** `skills/baoyu-post-to-wechat/scripts/wechat-api.ts`

- Added `htmlToPlainText()` function (lines 86-137)
- Modified `publishToDraft()` to use the new function for `newspic` content

## Testing

Tested with various HTML inputs:

| Input | Old Output | New Output |
|-------|-----------|-----------|
| `<p>?????/p><p>?????/p>` | `?????????` | `?????n????? |
| `<p>??nbsp;??nbsp;??/p>` | `??nbsp;??nbsp;?? | `????? |
| `<p>5 &lt; 10 &amp; 20 &gt; 15</p>` | `5 &lt; 10 &amp; 20 &gt; 15` | `5 < 10 & 20 > 15` |
| Multiple images with text | HTML tags preserved | Clean plain text |

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes tested locally
- [x] Related issue referenced