### PR TITLE
feat(baoyu-md): support Obsidian wikilink image syntax

### DIFF
--- a/packages/baoyu-md/src/images.test.ts
+++ b/packages/baoyu-md/src/images.test.ts
@@ -45,6 +45,60 @@ test("image extension and local fallback resolution handle common path variants"
   assert.equal(resolved, path.join(baseDir, "figure.webp"));
 });
 
+test("replaceMarkdownImagesWithPlaceholders handles Obsidian wikilink syntax", () => {
+  const result = replaceMarkdownImagesWithPlaceholders(
+    `![[image.png]]\n\nText\n\n![[diagram.webp|my diagram]]`,
+    "IMG_",
+  );
+
+  assert.equal(result.markdown, `IMG_1\n\nText\n\nIMG_2`);
+  assert.deepEqual(result.images, [
+    { alt: "", originalPath: "image.png", placeholder: "IMG_1" },
+    { alt: "my diagram", originalPath: "diagram.webp", placeholder: "IMG_2" },
+  ]);
+});
+
+test("replaceMarkdownImagesWithPlaceholders handles wikilink with path", () => {
+  const result = replaceMarkdownImagesWithPlaceholders(
+    `![[Attachments/screenshot.png]]`,
+    "IMG_",
+  );
+
+  assert.equal(result.markdown, `IMG_1`);
+  assert.deepEqual(result.images, [
+    { alt: "", originalPath: "Attachments/screenshot.png", placeholder: "IMG_1" },
+  ]);
+});
+
+test("replaceMarkdownImagesWithPlaceholders handles mixed standard and wikilink images", () => {
+  const result = replaceMarkdownImagesWithPlaceholders(
+    `![[first.png]]\n\n![second](imgs/second.jpg)\n\n![[third.png|caption]]`,
+    "IMG_",
+  );
+
+  assert.equal(result.markdown, `IMG_1\n\nIMG_2\n\nIMG_3`);
+  assert.deepEqual(result.images, [
+    { alt: "", originalPath: "first.png", placeholder: "IMG_1" },
+    { alt: "second", originalPath: "imgs/second.jpg", placeholder: "IMG_2" },
+    { alt: "caption", originalPath: "third.png", placeholder: "IMG_3" },
+  ]);
+});
+
+test("resolveImagePath falls back to Attachments subdirectory", async (t) => {
+  const root = await makeTempDir("baoyu-md-attachments-");
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+
+  const baseDir = path.join(root, "article");
+  const tempDir = path.join(root, "tmp");
+  const attachDir = path.join(baseDir, "Attachments");
+  await fs.mkdir(attachDir, { recursive: true });
+  await fs.mkdir(tempDir, { recursive: true });
+  await fs.writeFile(path.join(attachDir, "photo.png"), "png");
+
+  const resolved = await resolveImagePath("photo.png", baseDir, tempDir, "test");
+  assert.equal(resolved, path.join(attachDir, "photo.png"));
+});
+
 test("resolveContentImages resolves image placeholders against the content directory", async (t) => {
   const root = await makeTempDir("baoyu-md-content-images-");
   t.after(() => fs.rm(root, { recursive: true, force: true }));

--- a/packages/baoyu-md/src/images.ts
+++ b/packages/baoyu-md/src/images.ts
@@ -24,13 +24,15 @@ export function replaceMarkdownImagesWithPlaceholders(
   const images: ImagePlaceholder[] = [];
   let imageCounter = 0;
 
-  const rewritten = markdown.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt, src) => {
+  // Combined pattern: Obsidian wikilink ![[path]] or ![[path|alt]], and standard ![alt](path)
+  const combined = /!\[\[([^\]|]+?)(?:\|([^\]]*))?\]\]|!\[([^\]]*)\]\(([^)]+)\)/g;
+  const rewritten = markdown.replace(combined, (_match, wikiSrc, wikiAlt, mdAlt, mdSrc) => {
     const placeholder = `${placeholderPrefix}${++imageCounter}`;
-    images.push({
-      alt,
-      originalPath: src,
-      placeholder,
-    });
+    if (wikiSrc != null) {
+      images.push({ alt: wikiAlt ?? "", originalPath: wikiSrc, placeholder });
+    } else {
+      images.push({ alt: mdAlt, originalPath: mdSrc, placeholder });
+    }
     return placeholder;
   });
 
@@ -150,6 +152,17 @@ function resolveLocalWithFallback(resolved: string, logLabel: string): string {
       `[${logLabel}] Image fallback: ${path.basename(resolved)} -> ${path.basename(alternative)}`,
     );
     return alternative;
+  }
+
+  // Obsidian attachment folder fallback: check Attachments/ subdirectory
+  const dir = path.dirname(resolved);
+  const filename = path.basename(resolved);
+  const attachmentsPath = path.join(dir, "Attachments", filename);
+  if (fs.existsSync(attachmentsPath)) {
+    console.error(
+      `[${logLabel}] Image fallback: ${filename} -> Attachments/${filename}`,
+    );
+    return attachmentsPath;
   }
 
   return resolved;

--- a/skills/baoyu-post-to-x/scripts/md-to-html.ts
+++ b/skills/baoyu-post-to-x/scripts/md-to-html.ts
@@ -182,7 +182,19 @@ async function resolveImagePath(imagePath: string, baseDir: string, tempDir: str
     return imagePath;
   }
 
-  return path.resolve(baseDir, imagePath);
+  const resolved = path.resolve(baseDir, imagePath);
+  if (fs.existsSync(resolved)) {
+    return resolved;
+  }
+
+  // Obsidian attachment folder fallback
+  const attachmentsPath = path.resolve(baseDir, 'Attachments', imagePath);
+  if (fs.existsSync(attachmentsPath)) {
+    console.error(`[md-to-html] Image fallback: ${imagePath} -> Attachments/${imagePath}`);
+    return attachmentsPath;
+  }
+
+  return resolved;
 }
 
 function escapeHtml(text: string): string {
@@ -318,10 +330,15 @@ export async function parseMarkdown(
     coverImagePath = findCoverImageNearMarkdown(baseDir);
   }
 
+  // Normalize Obsidian wikilink images to standard markdown before parsing
+  const normalizedBody = body.replace(/!\[\[([^\]|]+?)(?:\|([^\]]*))?\]\]/g, (_m, src, alt) => {
+    return `![${alt ?? ""}](${src})`;
+  });
+
   const images: Array<{ src: string; alt: string; blockIndex: number }> = [];
   let imageCounter = 0;
 
-  const { html, totalBlocks } = convertMarkdownToHtml(body, (src, alt) => {
+  const { html, totalBlocks } = convertMarkdownToHtml(normalizedBody, (src, alt) => {
     const placeholder = `XIMGPH_${++imageCounter}`;
     images.push({ src, alt, blockIndex: -1 });
     return placeholder;


### PR DESCRIPTION
## Summary
- Add support for Obsidian `![[filename.png]]` and `![[filename.png|alt]]` wikilink image syntax in `replaceMarkdownImagesWithPlaceholders()`
- Uses a single combined regex to preserve document order when mixing wikilinks and standard markdown images
- Add `Attachments/` subdirectory fallback in path resolution to match Obsidian default attachment folder convention

## Motivation
When publishing Obsidian markdown files via `baoyu-post-to-wechat`, inline images using wikilink syntax are silently skipped (reported as "Placeholder images: 0"). This affects all Obsidian users whose notes use the default `![[]]` syntax.

## Test plan
- [x] Added tests for basic wikilink `![[image.png]]`
- [x] Added tests for wikilink with alt text `![[image.png|alt]]`
- [x] Added tests for wikilink with path `![[Attachments/img.png]]`
- [x] Added tests for mixed standard + wikilink images (document order preserved)
- [x] Added tests for Attachments/ folder resolution fallback
- [x] All existing tests still pass