### PR TITLE
fix(baoyu-md, baoyu-post-to-x): decode URL-encoded image paths

### DIFF
--- a/packages/baoyu-md/src/images.test.ts
+++ b/packages/baoyu-md/src/images.test.ts
@@ -45,6 +45,20 @@ test("image extension and local fallback resolution handle common path variants"
   assert.equal(resolved, path.join(baseDir, "figure.webp"));
 });
 
+test("resolveImagePath decodes URL-encoded filenames with spaces", async (t) => {
+  const root = await makeTempDir("baoyu-md-urlencoded-");
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+
+  const baseDir = path.join(root, "article");
+  const tempDir = path.join(root, "tmp");
+  await fs.mkdir(baseDir, { recursive: true });
+  await fs.mkdir(tempDir, { recursive: true });
+  await fs.writeFile(path.join(baseDir, "Pasted image 20260524.png"), "png");
+
+  const resolved = await resolveImagePath("Pasted%20image%2020260524.png", baseDir, tempDir, "test");
+  assert.equal(resolved, path.join(baseDir, "Pasted image 20260524.png"));
+});
+
 test("resolveContentImages resolves image placeholders against the content directory", async (t) => {
   const root = await makeTempDir("baoyu-md-content-images-");
   t.after(() => fs.rm(root, { recursive: true, force: true }));

--- a/packages/baoyu-md/src/images.ts
+++ b/packages/baoyu-md/src/images.ts
@@ -103,9 +103,10 @@ export async function resolveImagePath(
     return localPath;
   }
 
-  const resolved = path.isAbsolute(imagePath)
-    ? imagePath
-    : path.resolve(baseDir, imagePath);
+  const decoded = decodeURIComponent(imagePath);
+  const resolved = path.isAbsolute(decoded)
+    ? decoded
+    : path.resolve(baseDir, decoded);
   return resolveLocalWithFallback(resolved, logLabel);
 }
 

--- a/skills/baoyu-post-to-x/scripts/md-to-html.ts
+++ b/skills/baoyu-post-to-x/scripts/md-to-html.ts
@@ -178,11 +178,12 @@ async function resolveImagePath(imagePath: string, baseDir: string, tempDir: str
     return localPath;
   }
 
-  if (path.isAbsolute(imagePath)) {
-    return imagePath;
+  const decoded = decodeURIComponent(imagePath);
+  if (path.isAbsolute(decoded)) {
+    return decoded;
   }
 
-  return path.resolve(baseDir, imagePath);
+  return path.resolve(baseDir, decoded);
 }
 
 function escapeHtml(text: string): string {


### PR DESCRIPTION
## Summary
- Add `decodeURIComponent()` before path resolution in `baoyu-md`'s shared `resolveImagePath()` and `baoyu-post-to-x`'s independent version
- Fixes Obsidian-pasted images with spaces in filenames (e.g. `Pasted%20image%2020260524.png` → `Pasted image 20260524.png`)

## Motivation
Obsidian creates markdown image links with URL-encoded filenames. The scripts try to open files with literal `%20` in the path, but the actual file on disk has spaces. This causes "Image not found" errors during WeChat and X Article publishing.

## Test plan
- [x] Added test: URL-encoded filename resolves to file with spaces
- [x] All existing tests pass (4 pass, 0 fail)
- [x] Verified manually with real Obsidian file containing `Pasted%20image` references