### PR TITLE
[codex] improve X article cover and Write button handling

### DIFF
--- a/skills/baoyu-post-to-x/SKILL.md
+++ b/skills/baoyu-post-to-x/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: baoyu-post-to-x
 description: Posts content and articles to X (Twitter). Supports regular posts with images/videos and X Articles (long-form Markdown). In Codex, honor explicit requests for the Codex Chrome plugin/@chrome by using the Chrome Extension workflow; otherwise use Chrome Computer Use when available and fall back to real Chrome CDP scripts only when allowed. Use when user asks to "post to X", "tweet", "publish to Twitter", or "share on X".
-version: 1.58.0
+version: 1.58.1
 metadata:
   openclaw:
     homepage: https://github.com/JimLiu/baoyu-skills#baoyu-post-to-x
@@ -76,23 +76,24 @@ Use this mode whenever the user requests the Codex Chrome plugin, `@chrome`, or 
    ${BUN_X} {baseDir}/scripts/md-to-html.ts article.md --save-html /tmp/x-article-body.html > /tmp/x-article.json
    ```
 2. Read the JSON output for `title`, `coverImage`, and `contentImages` (`placeholder` → `localPath`).
-3. Open or create the article draft at `https://x.com/compose/articles`.
-4. Upload the cover with the Chrome plugin file chooser flow. If upload is blocked by extension permissions, stop and report the exact permission fix above.
-5. Fill the title, then copy rich HTML:
+3. If the user asks for a generated cover, or the parsed cover is missing/unsuitable, follow **Generated Article Covers** and use that file as `coverImage`.
+4. Open or create the article draft at `https://x.com/compose/articles`.
+5. Upload the cover with the Chrome plugin file chooser flow. If upload is blocked by extension permissions, stop and report the exact permission fix above.
+6. Fill the title, then copy rich HTML:
    ```bash
    ${BUN_X} {baseDir}/scripts/copy-to-clipboard.ts html --file /tmp/x-article-body.html
    ```
-6. Paste into the article body with a real paste keystroke through the Chrome plugin. On macOS use `Meta+V`.
-7. Verify the editor text contains the article body and `XIMGPH_` placeholders. Do not rely on `tab.clipboard.readText()` as proof of the system clipboard after shell clipboard writes; on macOS verify with `pbpaste` if needed.
-8. For each `contentImages` item in placeholder order:
+7. Paste into the article body with a real paste keystroke through the Chrome plugin. On macOS use `Meta+V`.
+8. Verify the editor text contains the article body and `XIMGPH_` placeholders. Do not rely on `tab.clipboard.readText()` as proof of the system clipboard after shell clipboard writes; on macOS verify with `pbpaste` if needed.
+9. For each `contentImages` item in placeholder order:
    - Locate the visible placeholder text (`XIMGPH_N`) and click it to place the caret there.
    - Open the toolbar menu `Insert` -> `Media`.
    - In the modal, click the icon button with `aria-label="Add photos or video"`; do not click the text/dropzone or hidden file input.
    - Use the file chooser to upload that image's `localPath`.
    - After the image appears, if `XIMGPH_N` remains above it, select exactly that placeholder and press `Delete` first. Use `Backspace` only if `Delete` fails and the selected text is confirmed to be exactly the placeholder.
    - Verify the placeholder count for that `XIMGPH_N` is `0`.
-9. Open Preview and verify title, cover, body, links, and images.
-10. Ask for explicit confirmation before clicking `Publish`.
+10. Open Preview and verify title, cover, body, links, and images.
+11. Ask for explicit confirmation before clicking `Publish`.
 
 ## Preferences (EXTEND.md)
 
@@ -143,6 +144,31 @@ Checks: Chrome, profile isolation, Bun, Accessibility, clipboard, paste keystrok
 
 ---
 
+## Generated Article Covers
+
+X Articles recommends a `5:2` cover image. If the article has no suitable cover, or the user asks for one, generate a simple cover before opening Preview.
+
+1. Read the Markdown title and skim the first sections to identify the core theme, audience, and visual metaphor.
+2. Generate a wide `5:2` image with the available image-generation tool. If no image-generation tool is available, ask the user to provide a cover image or continue without generating one.
+3. Use no text, letters, logos, or watermark. Prefer a clean editorial scene with generous safe margins, because X may crop the cover in cards and previews.
+4. Save the generated image beside the article or in another durable project path, then normalize it to an exact `5:2` size such as `2000x800`.
+   - macOS, for outputs already close to `5:2`: `sips -z 800 2000 input.png --out cover-5x2.png`
+   - ImageMagick, for center-cropping without distortion: `magick input.png -resize 2000x800^ -gravity center -extent 2000x800 cover-5x2.png`
+5. Verify dimensions before upload:
+   ```bash
+   sips -g pixelWidth -g pixelHeight cover-5x2.png
+   ```
+6. Inspect the result visually for clutter, text artifacts, and bad crops.
+7. Use the generated image as the article cover only; do not insert it into the body unless the user explicitly asks.
+
+Prompt pattern:
+
+```text
+Create a concise 5:2 X Article cover for: <article title/theme>.
+Visualize the article's subject with a simple editorial illustration, generous safe margins, and no text.
+No letters, logos, UI brand names, watermark, or clutter.
+```
+
 ## Chrome Computer Use Mode
 
 Use this mode when the user explicitly asks for Chrome Computer Use, or when no Chrome-plugin preference is stated and Codex can control `Google Chrome` with Computer Use. This uses the user's existing Chrome window, cookies, login, extensions, and X session.
@@ -182,21 +208,22 @@ Use this mode when the user explicitly asks for Chrome Computer Use, or when no 
    ${BUN_X} {baseDir}/scripts/md-to-html.ts article.md --save-html /tmp/x-article-body.html > /tmp/x-article.json
    ```
 2. Read the JSON output for `title`, `coverImage`, and `contentImages` (`placeholder` → `localPath`).
-3. In Chrome, open `https://x.com/compose/articles`, create or open the draft, upload the cover if present, and fill the title.
-4. Copy rich HTML to the clipboard:
+3. If the user asks for a generated cover, or the parsed cover is missing/unsuitable, follow **Generated Article Covers** and use that file as `coverImage`.
+4. In Chrome, open `https://x.com/compose/articles`, create or open the draft, upload the cover if present, and fill the title.
+5. Copy rich HTML to the clipboard:
    ```bash
    ${BUN_X} {baseDir}/scripts/copy-to-clipboard.ts html --file /tmp/x-article-body.html
    ```
-5. Paste into the article body with Computer Use.
-6. For each `contentImages` entry in placeholder order:
+6. Paste into the article body with Computer Use.
+7. For each `contentImages` entry in placeholder order:
    - Locate the exact visible placeholder text such as `XIMGPH_3` and click it to set the insertion point.
    - Open the toolbar `Insert` dropdown, choose `Media`, then click the modal's icon button labeled `Add photos or video`.
    - Use the native file picker to choose the image's `localPath`.
    - Wait until the image block appears and any upload activity is finished.
    - If the placeholder remains above the inserted image, reselect exactly that placeholder text and press `Delete` first. Use `Backspace` only if `Delete` fails and the selected text is confirmed to be exactly the placeholder.
-7. Verify no `XIMGPH_` placeholders remain and the expected images appear.
-8. Open Preview and verify title, cover, body, links, and images.
-9. Ask for explicit confirmation before clicking `Publish`.
+8. Verify no `XIMGPH_` placeholders remain and the expected images appear.
+9. Open Preview and verify title, cover, body, links, and images.
+10. Ask for explicit confirmation before clicking `Publish`.
 
 If Computer Use selection, toolbar upload, or file-picker control becomes unreliable, stop and report the blocker instead of switching to the Chrome plugin or CDP silently.
 
@@ -286,6 +313,7 @@ Long-form Markdown articles (requires X Premium).
 ```bash
 ${BUN_X} {baseDir}/scripts/x-article.ts article.md
 ${BUN_X} {baseDir}/scripts/x-article.ts article.md --cover ./cover.jpg
+${BUN_X} {baseDir}/scripts/x-article.ts article.md --cover ./cover-5x2.png
 ```
 
 **Parameters**:
@@ -296,6 +324,8 @@ ${BUN_X} {baseDir}/scripts/x-article.ts article.md --cover ./cover.jpg
 | `--title <text>` | Override title |
 
 **Frontmatter**: `title`, `cover_image` supported in YAML front matter.
+
+For generated covers, follow **Generated Article Covers** first, then pass the exact `5:2` file with `--cover` in CDP Script Mode or upload it through the visible cover slot in Chrome modes.
 
 **Codex mode note**: If the user explicitly requested the Codex Chrome plugin, follow **Codex Chrome Plugin Mode** above. If the user explicitly requested Chrome Computer Use, follow **Chrome Computer Use Mode**. Otherwise, prefer Chrome Computer Use; for Markdown articles with local content images, use the toolbar `Insert` -> `Media` image-upload workflow before falling back to `x-article.ts` in **CDP Script Mode**.
 

--- a/skills/baoyu-post-to-x/references/articles.md
+++ b/skills/baoyu-post-to-x/references/articles.md
@@ -119,6 +119,37 @@ Code blocks become blockquotes (X doesn't support code)
 3. **Placeholders**: Images in content use `XIMGPH_N` format
 4. **Insertion**: Placeholders are found, selected, and replaced with actual images
 
+## Generated Cover Images
+
+X recommends a `5:2` article cover. When the Markdown lacks a good cover, or the user asks for one, generate a separate cover image before uploading the draft.
+
+1. Use the article title and opening sections to derive a simple visual metaphor.
+2. Generate a clean `5:2` cover with the available image-generation tool. If no image-generation tool is available, ask the user to provide a cover image or continue without generating one.
+3. Use no text, letters, logos, or watermark. Keep generous safe margins for X preview crops.
+4. Save the file in a durable path beside the article or project assets.
+5. Normalize the final asset to an exact `5:2` size such as `2000x800`:
+   ```bash
+   # macOS, for outputs already close to 5:2
+   sips -z 800 2000 input.png --out cover-5x2.png
+
+   # ImageMagick, for center-cropping without distortion
+   magick input.png -resize 2000x800^ -gravity center -extent 2000x800 cover-5x2.png
+   ```
+6. Verify dimensions before upload:
+   ```bash
+   sips -g pixelWidth -g pixelHeight cover-5x2.png
+   ```
+7. Inspect the result visually for clutter, text artifacts, and bad crops.
+8. Upload this generated image only to the article cover slot. Do not also insert it into the body unless the user asks.
+
+Prompt pattern:
+
+```text
+Create a concise 5:2 X Article cover for: <article title/theme>.
+Visualize the article's subject with a simple editorial illustration, generous safe margins, and no text.
+No letters, logos, UI brand names, watermark, or clutter.
+```
+
 ## Markdown to HTML Script
 
 Convert markdown and inspect structure:
@@ -173,27 +204,28 @@ JSON output:
 2. **Connect**: initialize the Chrome plugin browser client and verify with `browser.user.openTabs()`.
 3. **Parse Markdown**: run `md-to-html.ts --save-html /tmp/x-article-body.html > /tmp/x-article.json`.
 4. **Read the map**: use `/tmp/x-article.json` for `title`, `coverImage`, and `contentImages`.
-5. **Open X Articles**: open or claim a Chrome tab for `https://x.com/compose/articles`.
-6. **Create Draft**: click the create/write button if needed, or open the target draft.
-7. **Upload Cover**: use the Chrome plugin file chooser flow. If file upload returns `Not allowed`, report the Chrome Extension file-access fix and stop.
-8. **Fill Title**: fill the title field.
-9. **Paste Content**:
+5. **Prepare Cover**: if the user asks for a generated cover, or `coverImage` is missing/unsuitable, follow **Generated Cover Images** and use that file as `coverImage`.
+6. **Open X Articles**: open or claim a Chrome tab for `https://x.com/compose/articles`.
+7. **Create Draft**: click the create/write button if needed, or open the target draft.
+8. **Upload Cover**: use the Chrome plugin file chooser flow. If file upload returns `Not allowed`, report the Chrome Extension file-access fix and stop.
+9. **Fill Title**: fill the title field.
+10. **Paste Content**:
    - Run `copy-to-clipboard.ts html --file /tmp/x-article-body.html`.
    - Click the article body.
    - Press `Meta+V` on macOS or `Control+V` on Windows/Linux through the Chrome plugin.
    - Verify the article body appeared and contains `XIMGPH_` placeholders. On macOS, use `pbpaste` to verify shell-written system clipboard contents if paste is suspicious; `tab.clipboard.readText()` may not reflect the system clipboard after shell writes.
-10. **Insert Images**: for each `contentImages` item in placeholder order:
+11. **Insert Images**: for each `contentImages` item in placeholder order:
    - Locate the exact visible placeholder text (`XIMGPH_N`) and click it to put the insertion point there.
    - Open the editor toolbar dropdown `Insert` and choose `Media`.
    - In the `Insert` modal, click the icon button with `aria-label="Add photos or video"`; do not click the "Choose a file or drag it here" text/dropzone or hidden file input.
    - Use the Chrome plugin file chooser flow to upload that image's `localPath`.
    - Wait until the image block appears. If `XIMGPH_N` remains above the image, select exactly that placeholder and press `Delete` first; use `Backspace` only if `Delete` fails and the selected text is confirmed to be exactly the placeholder.
    - Verify that placeholder's count is `0` before continuing.
-11. **Verify**:
+12. **Verify**:
    - Inspect the editor for `XIMGPH_` residue.
    - Confirm the expected number of image blocks is visible.
    - Open Preview and verify title, cover, body, links, and images.
-12. **Publish Safety**: ask the user for explicit final confirmation before clicking `Publish`.
+13. **Publish Safety**: ask the user for explicit final confirmation before clicking `Publish`.
 
 If the Chrome plugin reports `native pipe is closed`, retry one lightweight browser call after 2 seconds, then run the Chrome skill health checks. If Chrome, the extension, and native host are healthy, ask the user before opening a new Chrome window and retrying.
 
@@ -202,48 +234,50 @@ If the Chrome plugin reports `native pipe is closed`, retry one lightweight brow
 1. **Detect Computer Use**: call `get_app_state` for `Google Chrome`; use `tool_search` first if the tools are not visible.
 2. **Parse Markdown**: run `md-to-html.ts --save-html /tmp/x-article-body.html > /tmp/x-article.json`.
 3. **Read the map**: use `/tmp/x-article.json` for `title`, `coverImage`, and `contentImages`.
-4. **Open X Articles**: use Chrome Computer Use to navigate to `https://x.com/compose/articles`.
-5. **Create Draft**: click the create/write button if needed, or open the target draft.
-6. **Upload Cover**: if `coverImage` exists, use Chrome's visible upload/file picker UI. If the file picker cannot be operated reliably, stop and ask for help rather than switching to CDP silently.
-7. **Fill Title**: type the title into the title field.
-8. **Paste Content**:
+4. **Prepare Cover**: if the user asks for a generated cover, or `coverImage` is missing/unsuitable, follow **Generated Cover Images** and use that file as `coverImage`.
+5. **Open X Articles**: use Chrome Computer Use to navigate to `https://x.com/compose/articles`.
+6. **Create Draft**: click the create/write button if needed, or open the target draft.
+7. **Upload Cover**: if `coverImage` exists, use Chrome's visible upload/file picker UI. If the file picker cannot be operated reliably, stop and ask for help rather than switching to CDP silently.
+8. **Fill Title**: type the title into the title field.
+9. **Paste Content**:
    - Run `copy-to-clipboard.ts html --file /tmp/x-article-body.html`.
    - Click the article body.
    - Press `super+v` on macOS or `control+v` on Windows/Linux with Computer Use.
-9. **Insert Images**: for each `contentImages` item in placeholder order:
+10. **Insert Images**: for each `contentImages` item in placeholder order:
    - Locate the exact visible placeholder text (`XIMGPH_N`) and click it to put the insertion point there.
    - Open the editor toolbar dropdown `Insert`, choose `Media`, then click the icon button with `aria-label="Add photos or video"` inside the modal.
    - Use the native file picker to choose that image's `localPath`.
    - Wait until the image block appears and upload activity is complete.
    - If `XIMGPH_N` remains above the inserted image, reselect exactly that placeholder text and press `Delete` first; use `Backspace` only if `Delete` fails and the Computer Use state confirms the selected text is exactly the placeholder.
    - Confirm that placeholder is gone before continuing.
-10. **Verify**:
+11. **Verify**:
    - Inspect the Computer Use state for `XIMGPH_` residue.
    - Confirm the expected number of image blocks is visible.
    - Open Preview and verify title, cover, body, links, and images.
-11. **Publish Safety**: ask the user for explicit final confirmation before clicking `Publish`.
+12. **Publish Safety**: ask the user for explicit final confirmation before clicking `Publish`.
 
 ## CDP Script Workflow (Fallback)
 
 1. **Parse Markdown**: Extract title, cover, content images, generate HTML
-2. **Launch Chrome**: Real browser with CDP, persistent login
-3. **Navigate**: Open `x.com/compose/articles`
-4. **Create Article**: Click create button if on list page
-5. **Upload Cover**: Use file input for cover image
-6. **Fill Title**: Type title into title field
-7. **Paste Content**: Copy HTML to clipboard, paste into editor
-8. **Insert Images**: For each placeholder in placeholder order:
+2. **Prepare Cover**: if the user asks for a generated cover, or the parsed cover is missing/unsuitable, follow **Generated Cover Images** and pass it with `--cover cover-5x2.png`
+3. **Launch Chrome**: Real browser with CDP, persistent login
+4. **Navigate**: Open `x.com/compose/articles`
+5. **Create Article**: Click create button if on list page
+6. **Upload Cover**: Use file input for cover image
+7. **Fill Title**: Type title into title field
+8. **Paste Content**: Copy HTML to clipboard, paste into editor
+9. **Insert Images**: For each placeholder in placeholder order:
    - Find and click the placeholder text in the editor
    - Use `Insert` -> `Media`
    - Click the modal's icon button labeled `Add photos or video`
    - Upload the matching image file
    - Delete the leftover placeholder text with `Delete` after the image appears
-9. **Post-Composition Check** (automatic):
+10. **Post-Composition Check** (automatic):
    - Scan editor for remaining `XIMGPH_` placeholders
    - Compare expected vs actual image count
    - Warn if issues found
-10. **Review**: Browser stays open for 60s preview
-11. **Publish**: Only with `--submit` flag and explicit user confirmation
+11. **Review**: Browser stays open for 60s preview
+12. **Publish**: Only with `--submit` flag and explicit user confirmation
 
 ## Example Session
 

--- a/skills/baoyu-post-to-x/scripts/x-article.test.ts
+++ b/skills/baoyu-post-to-x/scripts/x-article.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CLICK_WRITE_BUTTON_EXPRESSION } from './x-article.ts';
+
+test('CLICK_WRITE_BUTTON_EXPRESSION clicks the closest clickable Write button ancestor', () => {
+  let innerClicked = false;
+  let outerClicked = false;
+
+  const inner = {
+    click() {
+      innerClicked = true;
+    },
+    closest(selector: string) {
+      assert.equal(selector, 'a, button, [role="button"]');
+      return {
+        click() {
+          outerClicked = true;
+        },
+      };
+    },
+  };
+
+  const previousDocument = globalThis.document;
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: {
+      querySelector(selector: string) {
+        assert.equal(selector, '[data-testid="empty_state_button_text"]');
+        return inner;
+      },
+    },
+  });
+
+  try {
+    Function(CLICK_WRITE_BUTTON_EXPRESSION)();
+  } finally {
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: previousDocument,
+    });
+  }
+
+  assert.equal(outerClicked, true);
+  assert.equal(innerClicked, false);
+});

--- a/skills/baoyu-post-to-x/scripts/x-article.ts
+++ b/skills/baoyu-post-to-x/scripts/x-article.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { parseMarkdown } from './md-to-html.js';
 import {
@@ -19,6 +20,12 @@ import {
 } from './x-utils.js';
 
 const X_ARTICLES_URL = 'https://x.com/compose/articles';
+
+export const CLICK_WRITE_BUTTON_EXPRESSION = `(() => {
+  const inner = document.querySelector('[data-testid="empty_state_button_text"]');
+  const clickable = inner?.closest('a, button, [role="button"]') ?? inner;
+  clickable?.click();
+})()`;
 
 const I18N_SELECTORS = {
   titleInput: [
@@ -169,7 +176,7 @@ export async function publishArticle(options: ArticleOptions): Promise<void> {
     if (writeButtonFound) {
       console.log('[x-article] Clicking Write button...');
       await cdp.send('Runtime.evaluate', {
-        expression: `document.querySelector('[data-testid="empty_state_button_text"]')?.click()`,
+        expression: CLICK_WRITE_BUTTON_EXPRESSION,
       }, { sessionId });
       await sleep(2000);
     } else {
@@ -823,7 +830,9 @@ async function main(): Promise<void> {
   await publishArticle({ markdownPath, title, coverImage, submit, profileDir });
 }
 
-await main().catch((err) => {
-  console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main().catch((err) => {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- click the nearest clickable ancestor for the X Articles `Write` text node
- add a regression test for the `Write` button click expression
- document the generated X Article cover workflow, including `5:2` sizing and cover upload across Chrome plugin, Computer Use, and CDP modes

## Why

X currently renders `[data-testid="empty_state_button_text"]` as an inner text node. Calling `.click()` on that node may not open the editor, so article publishing can stall on the drafts page even when the `Write` control is visible.

X Articles also recommends a `5:2` cover image. The skill now records the practical flow for generating a simple no-text cover, normalizing it to an exact ratio, verifying dimensions, and uploading it as the article cover rather than as a body image.

## Validation

- `bun test skills/baoyu-post-to-x/scripts/x-utils.test.ts skills/baoyu-post-to-x/scripts/md-to-html.test.ts skills/baoyu-post-to-x/scripts/x-article.test.ts`
- `bun skills/baoyu-post-to-x/scripts/x-article.ts --help`
- `git diff --check`
