### PR TITLE
feat(baoyu-image-gen): migrate Google image generation to GA Gemini endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 /baoyu-image-gen --prompt "A cat" --image cat.png --provider openrouter
 
 # OpenRouter with reference images
-/baoyu-image-gen --prompt "Make it blue" --image out.png --provider openrouter --model google/gemini-3.1-flash-image-preview --ref source.png
+/baoyu-image-gen --prompt "Make it blue" --image out.png --provider openrouter --model google/gemini-3.1-flash-image --ref source.png
 
 # DashScope (Aliyun Tongyi Wanxiang)
 /baoyu-image-gen --prompt "一只可爱的猫" --image cat.png --provider dashscope
@@ -827,8 +827,8 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 | `OPENAI_IMAGE_MODEL` | OpenAI model | `gpt-image-2` |
 | `AZURE_OPENAI_DEPLOYMENT` | Azure default deployment name | - |
 | `AZURE_OPENAI_IMAGE_MODEL` | Backward-compatible Azure deployment/model alias | `gpt-image-2` |
-| `OPENROUTER_IMAGE_MODEL` | OpenRouter model | `google/gemini-3.1-flash-image-preview` |
-| `GOOGLE_IMAGE_MODEL` | Google model | `gemini-3-pro-image-preview` |
+| `OPENROUTER_IMAGE_MODEL` | OpenRouter model | `google/gemini-3.1-flash-image` |
+| `GOOGLE_IMAGE_MODEL` | Google model | `gemini-3-pro-image` |
 | `DASHSCOPE_IMAGE_MODEL` | DashScope model | `qwen-image-2.0-pro` |
 | `ZAI_IMAGE_MODEL` | Z.AI model | `glm-image` |
 | `BIGMODEL_IMAGE_MODEL` | Backward-compatible alias for Z.AI model | `glm-image` |
@@ -1225,14 +1225,14 @@ AZURE_OPENAI_DEPLOYMENT=gpt-image-2
 
 # OpenRouter
 OPENROUTER_API_KEY=sk-or-xxx
-OPENROUTER_IMAGE_MODEL=google/gemini-3.1-flash-image-preview
+OPENROUTER_IMAGE_MODEL=google/gemini-3.1-flash-image
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # OPENROUTER_HTTP_REFERER=https://your-app.example.com
 # OPENROUTER_TITLE=Your App Name
 
 # Google
 GOOGLE_API_KEY=xxx
-GOOGLE_IMAGE_MODEL=gemini-3-pro-image-preview
+GOOGLE_IMAGE_MODEL=gemini-3-pro-image
 # GOOGLE_BASE_URL=https://generativelanguage.googleapis.com/v1beta
 
 # DashScope (Aliyun Tongyi Wanxiang)

--- a/README.zh.md
+++ b/README.zh.md
@@ -741,7 +741,7 @@ AI 驱动的生成后端。
 /baoyu-image-gen --prompt "一只猫" --image cat.png --provider openrouter
 
 # OpenRouter + 参考图
-/baoyu-image-gen --prompt "把它变成蓝色" --image out.png --provider openrouter --model google/gemini-3.1-flash-image-preview --ref source.png
+/baoyu-image-gen --prompt "把它变成蓝色" --image out.png --provider openrouter --model google/gemini-3.1-flash-image --ref source.png
 
 # DashScope（阿里通义万相）
 /baoyu-image-gen --prompt "一只可爱的猫" --image cat.png --provider dashscope
@@ -818,8 +818,8 @@ AI 驱动的生成后端。
 | `OPENAI_IMAGE_MODEL` | OpenAI 模型 | `gpt-image-2` |
 | `AZURE_OPENAI_DEPLOYMENT` | Azure 默认部署名 | - |
 | `AZURE_OPENAI_IMAGE_MODEL` | 兼容旧配置的 Azure 部署/模型别名 | `gpt-image-2` |
-| `OPENROUTER_IMAGE_MODEL` | OpenRouter 模型 | `google/gemini-3.1-flash-image-preview` |
-| `GOOGLE_IMAGE_MODEL` | Google 模型 | `gemini-3-pro-image-preview` |
+| `OPENROUTER_IMAGE_MODEL` | OpenRouter 模型 | `google/gemini-3.1-flash-image` |
+| `GOOGLE_IMAGE_MODEL` | Google 模型 | `gemini-3-pro-image` |
 | `DASHSCOPE_IMAGE_MODEL` | DashScope 模型 | `qwen-image-2.0-pro` |
 | `ZAI_IMAGE_MODEL` | Z.AI 模型 | `glm-image` |
 | `BIGMODEL_IMAGE_MODEL` | Z.AI 模型向后兼容别名 | `glm-image` |
@@ -1216,14 +1216,14 @@ AZURE_OPENAI_DEPLOYMENT=gpt-image-2
 
 # OpenRouter
 OPENROUTER_API_KEY=sk-or-xxx
-OPENROUTER_IMAGE_MODEL=google/gemini-3.1-flash-image-preview
+OPENROUTER_IMAGE_MODEL=google/gemini-3.1-flash-image
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # OPENROUTER_HTTP_REFERER=https://your-app.example.com
 # OPENROUTER_TITLE=你的应用名
 
 # Google
 GOOGLE_API_KEY=xxx
-GOOGLE_IMAGE_MODEL=gemini-3-pro-image-preview
+GOOGLE_IMAGE_MODEL=gemini-3-pro-image
 # GOOGLE_BASE_URL=https://generativelanguage.googleapis.com/v1beta
 
 # DashScope（阿里通义万相）

--- a/skills/baoyu-image-gen/SKILL.md
+++ b/skills/baoyu-image-gen/SKILL.md
@@ -179,7 +179,7 @@ For OpenAI, the built-in default is `gpt-image-2`. `gpt-image-1.5`, `gpt-image-1
 
 For Azure, `--model` / `default_model.azure` is the Azure deployment name. `AZURE_OPENAI_DEPLOYMENT` is the preferred env var; `AZURE_OPENAI_IMAGE_MODEL` is kept as a backward-compatible alias. If your Azure deployment is named after the underlying model, use `gpt-image-2`; otherwise use the exact custom deployment name.
 
-EXTEND.md overrides env vars: if EXTEND.md sets `default_model.google: "gemini-3-pro-image-preview"` and the env var sets `GOOGLE_IMAGE_MODEL=gemini-3.1-flash-image-preview`, EXTEND.md wins.
+EXTEND.md overrides env vars: if EXTEND.md sets `default_model.google: "gemini-3-pro-image"` and the env var sets `GOOGLE_IMAGE_MODEL=gemini-3.1-flash-image`, EXTEND.md wins.
 
 **Display model info before each generation**:
 

--- a/skills/baoyu-image-gen/references/config/first-time-setup.md
+++ b/skills/baoyu-image-gen/references/config/first-time-setup.md
@@ -69,9 +69,9 @@ Only show if user selected Google or auto-detect (no explicit provider).
 header: "Google Model"
 question: "Default Google image generation model?"
 options:
-  - label: "gemini-3-pro-image-preview (Recommended)"
+  - label: "gemini-3-pro-image (Recommended)"
     description: "Highest quality, best for production use"
-  - label: "gemini-3.1-flash-image-preview"
+  - label: "gemini-3.1-flash-image"
     description: "Fast generation, good quality, lower cost"
   - label: "gemini-3-flash-preview"
     description: "Fast generation, balanced quality and speed"
@@ -85,7 +85,7 @@ Only show if user selected OpenRouter.
 header: "OpenRouter Model"
 question: "Default OpenRouter image generation model?"
 options:
-  - label: "google/gemini-3.1-flash-image-preview (Recommended)"
+  - label: "google/gemini-3.1-flash-image (Recommended)"
     description: "Best general-purpose OpenRouter image model with reference-image workflows"
   - label: "google/gemini-2.5-flash-image-preview"
     description: "Fast Gemini preview model on OpenRouter"
@@ -202,9 +202,9 @@ When EXTEND.md exists but `default_model.[current_provider]` is null, ask ONLY t
 header: "Google Model"
 question: "Choose a default Google image generation model?"
 options:
-  - label: "gemini-3-pro-image-preview (Recommended)"
+  - label: "gemini-3-pro-image (Recommended)"
     description: "Highest quality, best for production use"
-  - label: "gemini-3.1-flash-image-preview"
+  - label: "gemini-3.1-flash-image"
     description: "Fast generation, good quality, lower cost"
   - label: "gemini-3-flash-preview"
     description: "Fast generation, balanced quality and speed"
@@ -249,7 +249,7 @@ Notes for Azure setup:
 header: "OpenRouter Model"
 question: "Choose a default OpenRouter image generation model?"
 options:
-  - label: "google/gemini-3.1-flash-image-preview (Recommended)"
+  - label: "google/gemini-3.1-flash-image (Recommended)"
     description: "Recommended for image output and reference-image edits"
   - label: "google/gemini-2.5-flash-image-preview"
     description: "Fast preview-oriented image generation"

--- a/skills/baoyu-image-gen/references/config/preferences-schema.md
+++ b/skills/baoyu-image-gen/references/config/preferences-schema.md
@@ -22,10 +22,10 @@ default_image_size: null    # 1K|2K|4K|null (Google/OpenRouter, overrides qualit
 default_image_api_dialect: null  # openai-native|ratio-metadata|null (OpenAI-compatible gateways; null = use env/default)
 
 default_model:
-  google: null              # e.g., "gemini-3-pro-image-preview", "gemini-3.1-flash-image-preview"
+  google: null              # e.g., "gemini-3-pro-image", "gemini-3.1-flash-image"
   openai: null              # e.g., "gpt-image-2", "gpt-image-1.5", "gpt-image-1"
   azure: null               # Azure deployment name, e.g., "gpt-image-2" or "image-prod"
-  openrouter: null          # e.g., "google/gemini-3.1-flash-image-preview"
+  openrouter: null          # e.g., "google/gemini-3.1-flash-image"
   dashscope: null           # e.g., "qwen-image-2.0-pro"
   zai: null                 # e.g., "glm-image"
   minimax: null             # e.g., "image-01"
@@ -110,10 +110,10 @@ default_aspect_ratio: "16:9"
 default_image_size: 2K
 default_image_api_dialect: null
 default_model:
-  google: "gemini-3-pro-image-preview"
+  google: "gemini-3-pro-image"
   openai: "gpt-image-2"
   azure: "gpt-image-2"
-  openrouter: "google/gemini-3.1-flash-image-preview"
+  openrouter: "google/gemini-3.1-flash-image"
   dashscope: "qwen-image-2.0-pro"
   zai: "glm-image"
   minimax: "image-01"

--- a/skills/baoyu-image-gen/references/providers/openrouter.md
+++ b/skills/baoyu-image-gen/references/providers/openrouter.md
@@ -1,12 +1,12 @@
 # OpenRouter
 
-Read when the user picks `--provider openrouter`. Default model is `google/gemini-3.1-flash-image-preview`.
+Read when the user picks `--provider openrouter`. Default model is `google/gemini-3.1-flash-image`.
 
 ## Common Models
 
 Use full OpenRouter model IDs:
 
-- `google/gemini-3.1-flash-image-preview` (recommended — supports image output and reference-image workflows)
+- `google/gemini-3.1-flash-image` (recommended — supports image output and reference-image workflows)
 - `google/gemini-2.5-flash-image-preview`
 - `black-forest-labs/flux.2-pro`
 - Any other OpenRouter image-capable model ID

--- a/skills/baoyu-image-gen/references/usage-examples.md
+++ b/skills/baoyu-image-gen/references/usage-examples.md
@@ -34,13 +34,13 @@ ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider a
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cinematic landscape" --image out.png --provider openai --model gpt-image-2 --size 3840x2160
 
 # Google with explicit model
-${BUN_X} {baseDir}/scripts/main.ts --prompt "Make blue" --image out.png --provider google --model gemini-3-pro-image-preview --ref source.png
+${BUN_X} {baseDir}/scripts/main.ts --prompt "Make blue" --image out.png --provider google --model gemini-3-pro-image --ref source.png
 
 # OpenRouter (recommended default)
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider openrouter
 
 # OpenRouter with reference
-${BUN_X} {baseDir}/scripts/main.ts --prompt "Make blue" --image out.png --provider openrouter --model google/gemini-3.1-flash-image-preview --ref source.png
+${BUN_X} {baseDir}/scripts/main.ts --prompt "Make blue" --image out.png --provider openrouter --model google/gemini-3.1-flash-image --ref source.png
 
 # DashScope (default model)
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "一只可爱的猫" --image out.png --provider dashscope

--- a/skills/baoyu-image-gen/scripts/main.test.ts
+++ b/skills/baoyu-image-gen/scripts/main.test.ts
@@ -142,7 +142,7 @@ default_aspect_ratio: '16:9'
 default_image_size: 2K
 default_image_api_dialect: ratio-metadata
 default_model:
-  google: gemini-3-pro-image-preview
+  google: gemini-3-pro-image
   openai: gpt-image-2
   zai: glm-image
   azure: image-prod
@@ -174,7 +174,7 @@ batch:
   assert.equal(config.default_aspect_ratio, "16:9");
   assert.equal(config.default_image_size, "2K");
   assert.equal(config.default_image_api_dialect, "ratio-metadata");
-  assert.equal(config.default_model?.google, "gemini-3-pro-image-preview");
+  assert.equal(config.default_model?.google, "gemini-3-pro-image");
   assert.equal(config.default_model?.openai, "gpt-image-2");
   assert.equal(config.default_model?.zai, "glm-image");
   assert.equal(config.default_model?.azure, "image-prod");

--- a/skills/baoyu-image-gen/scripts/main.ts
+++ b/skills/baoyu-image-gen/scripts/main.ts
@@ -126,8 +126,8 @@ Environment variables:
   JIMENG_SECRET_ACCESS_KEY  Jimeng Secret Access Key
   ARK_API_KEY               Seedream/Ark API key
   OPENAI_IMAGE_MODEL        Default OpenAI model (gpt-image-2)
-  OPENROUTER_IMAGE_MODEL    Default OpenRouter model (google/gemini-3.1-flash-image-preview)
-  GOOGLE_IMAGE_MODEL        Default Google model (gemini-3-pro-image-preview)
+  OPENROUTER_IMAGE_MODEL    Default OpenRouter model (google/gemini-3.1-flash-image)
+  GOOGLE_IMAGE_MODEL        Default Google model (gemini-3-pro-image)
   DASHSCOPE_IMAGE_MODEL     Default DashScope model (qwen-image-2.0-pro)
   ZAI_IMAGE_MODEL           Default Z.AI model (glm-image)
   BIGMODEL_IMAGE_MODEL      Backward-compatible alias for Z.AI model (glm-image)

--- a/skills/baoyu-image-gen/scripts/providers/google.test.ts
+++ b/skills/baoyu-image-gen/scripts/providers/google.test.ts
@@ -67,6 +67,9 @@ test("Google provider helpers normalize model IDs and select image size defaults
     "gemini-3.1-flash-image-preview",
   );
   assert.equal(isGoogleMultimodal("models/gemini-3-pro-image-preview"), true);
+  assert.equal(isGoogleMultimodal("gemini-3-pro-image"), true);
+  assert.equal(isGoogleMultimodal("gemini-3.1-flash-image"), true);
+  assert.equal(isGoogleMultimodal("models/gemini-3-pro-image"), true);
   assert.equal(isGoogleImagen("imagen-3.0-generate-002"), true);
   assert.equal(getGoogleImageSize(makeArgs({ imageSize: null, quality: "2k" })), "2K");
   assert.equal(getGoogleImageSize(makeArgs({ imageSize: "4K", quality: "normal" })), "4K");

--- a/skills/baoyu-image-gen/scripts/providers/google.ts
+++ b/skills/baoyu-image-gen/scripts/providers/google.ts
@@ -4,6 +4,8 @@ import { execFileSync } from "node:child_process";
 import type { CliArgs } from "../types";
 
 const GOOGLE_MULTIMODAL_MODELS = [
+  "gemini-3-pro-image",
+  "gemini-3.1-flash-image",
   "gemini-3-pro-image-preview",
   "gemini-3-flash-preview",
   "gemini-3.1-flash-image-preview",
@@ -333,7 +335,7 @@ export async function generateImage(
   if (isGoogleImagen(model)) {
     if (args.referenceImages.length > 0) {
       throw new Error(
-        "Reference images are not supported with Imagen models. Use gemini-3-pro-image-preview, gemini-3-flash-preview, or gemini-3.1-flash-image-preview.",
+        "Reference images are not supported with Imagen models. Use a Gemini multimodal model such as gemini-3-pro-image, gemini-3.1-flash-image, gemini-3-pro-image-preview, gemini-3-flash-preview, or gemini-3.1-flash-image-preview.",
       );
     }
     return generateWithImagen(prompt, model, args);
@@ -341,7 +343,7 @@ export async function generateImage(
 
   if (!isGoogleMultimodal(model) && args.referenceImages.length > 0) {
     throw new Error(
-      "Reference images are only supported with Gemini multimodal models. Use gemini-3-pro-image-preview, gemini-3-flash-preview, or gemini-3.1-flash-image-preview.",
+      "Reference images are only supported with Gemini multimodal models such as gemini-3-pro-image, gemini-3.1-flash-image, gemini-3-pro-image-preview, gemini-3-flash-preview, or gemini-3.1-flash-image-preview.",
     );
   }
 

--- a/skills/baoyu-image-gen/scripts/providers/google.ts
+++ b/skills/baoyu-image-gen/scripts/providers/google.ts
@@ -16,7 +16,7 @@ const GOOGLE_IMAGEN_MODELS = [
 ];
 
 export function getDefaultModel(): string {
-  return process.env.GOOGLE_IMAGE_MODEL || "gemini-3-pro-image-preview";
+  return process.env.GOOGLE_IMAGE_MODEL || "gemini-3-pro-image";
 }
 
 export function normalizeGoogleModelId(model: string): string {

--- a/skills/baoyu-image-gen/scripts/providers/openrouter.ts
+++ b/skills/baoyu-image-gen/scripts/providers/openrouter.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { readFile } from "node:fs/promises";
 import type { CliArgs } from "../types";
 
-const DEFAULT_MODEL = "google/gemini-3.1-flash-image-preview";
+const DEFAULT_MODEL = "google/gemini-3.1-flash-image";
 const COMMON_ASPECT_RATIOS = [
   "1:1",
   "2:3",
@@ -67,7 +67,10 @@ function isTextAndImageModel(model: string): boolean {
 
 function getSupportedAspectRatios(model: string): Set<string> {
   const normalized = normalizeModelId(model);
-  if (normalized !== "google/gemini-3.1-flash-image-preview") {
+  if (
+    normalized !== "google/gemini-3.1-flash-image" &&
+    normalized !== "google/gemini-3.1-flash-image-preview"
+  ) {
     return new Set(COMMON_ASPECT_RATIOS);
   }
 


### PR DESCRIPTION
## What
Migrate the `baoyu-image-gen` Google/OpenRouter image generation to the GA Gemini image
endpoints (`gemini-3-pro-image`, `gemini-3.1-flash-image`):

1. Allow reference images (`--ref`) with the GA endpoints (multimodal whitelist + error messages).
2. Make GA the default model and sync all docs/examples/setup wizard accordingly.

## Why
Google Cloud is retiring the preview endpoints (`gemini-3-pro-image-preview`,
`gemini-3.1-flash-image-preview`) on 2026-07-17 in favor of the GA endpoints. The GA
models are the same multimodal models. Previously the whitelist and all defaults/docs
pointed at the soon-retired preview names, and `--ref` against a GA model was rejected.

## Changes
**Behavior**
- `google.ts`: add GA names to `GOOGLE_MULTIMODAL_MODELS`; default model → `gemini-3-pro-image`
- `openrouter.ts`: default model → `google/gemini-3.1-flash-image`; extended aspect-ratio
  support now matches both the GA and preview flash-image ids
- `main.ts`: help text defaults → GA

**Docs**
- README.md / README.zh.md (CLI examples, env-var default tables, sample `.env`)
- SKILL.md, references/usage-examples.md, references/config/preferences-schema.md,
  references/providers/openrouter.md, references/config/first-time-setup.md (wizard
  "(Recommended)" → GA)

**Tests**
- google.test.ts: assert GA models are detected as multimodal
- main.test.ts: default-model fixture/assertion → GA

## Notes
- Non-breaking: preview names remain in the multimodal whitelist and as selectable wizard
  options, so existing preview workflows keep working until the 2026-07-17 retirement.
- The reference-image error messages list both GA and preview names.

## References
- Gemini 3 Pro Image (preview): https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-pro-image-preview
- Gemini 3.1 Flash Image (preview): https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-flash-image-preview
- Gemini 3 Pro Image (GA): https://ai.google.dev/gemini-api/docs/models/gemini-3-pro-image
- Gemini 3.1 Flash Image (GA): https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-image
