### PR TITLE
feat(baoyu-post-to-wechat): add content_source_url support for original article link

### DIFF
--- a/skills/baoyu-post-to-wechat/SKILL.md
+++ b/skills/baoyu-post-to-wechat/SKILL.md
@@ -180,6 +180,7 @@ Ask method unless specified in EXTEND.md or CLI:
 | Title | Ask, or press Enter to auto-generate from content |
 | Summary | Frontmatter `description` → `summary` → ask or auto-generate |
 | Author | CLI `--author` → frontmatter `author` → EXTEND.md `default_author` |
+| Source URL | CLI `--source-url` → frontmatter `sourceUrl`/`contentSourceUrl`/`content_source_url` |
 
 Auto-generation: title = first H1/H2 or first sentence; summary = first paragraph, truncated to 120 chars.
 
@@ -194,7 +195,7 @@ Auto-generation: title = first H1/H2 or first sentence; summary = first paragrap
 **API method** (accepts `.md` or `.html`):
 
 ```bash
-${BUN_X} {baseDir}/scripts/wechat-api.ts <file> --theme <theme> [--color <color>] [--title <title>] [--summary <summary>] [--author <author>] [--cover <cover_path>] [--no-cite]
+${BUN_X} {baseDir}/scripts/wechat-api.ts <file> --theme <theme> [--color <color>] [--title <title>] [--summary <summary>] [--author <author>] [--cover <cover_path>] [--source-url <url>] [--no-cite]
 ```
 
 Always pass `--theme` even if it's `default`. Only pass `--color` when explicitly set by the user or EXTEND.md.
@@ -212,6 +213,7 @@ Any `--remote-*` flag implies `--remote`. CLI values override account-level then
 - `article_type`: `news` (default) or `newspic`
 - For `news`, include `thumb_media_id` (cover required)
 - Always include `need_open_comment` (default `1`) and `only_fans_can_comment` (default `0`) in the request body, even if the CLI doesn't expose them
+- For `news`, optionally include `content_source_url` (original article URL, shown as "阅读原文" link, max 1KB). Provide via `--source-url` CLI flag or frontmatter `sourceUrl`/`contentSourceUrl`/`content_source_url`
 
 **Browser method** (accepts `--markdown` or `--html`):
 

--- a/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
@@ -64,6 +64,7 @@ interface ArticleOptions {
   content: string;
   thumbMediaId: string;
   articleType: ArticleType;
+  contentSourceUrl?: string;
   imageMediaIds?: string[];
   needOpenComment?: number;
   onlyFansCanComment?: number;
@@ -379,6 +380,7 @@ async function publishToDraft(
     };
     if (options.author) article.author = options.author;
     if (options.digest) article.digest = options.digest;
+    if (options.contentSourceUrl) article.content_source_url = options.contentSourceUrl;
   }
 
   const res = await client(url, {
@@ -479,6 +481,7 @@ Options:
   --title <title>     Override title
   --author <name>     Author name (max 16 chars)
   --summary <text>    Article summary/digest (max 128 chars)
+  --source-url <url>  Original article URL ("阅读原文" link, max 1KB)
   --theme <name>      Theme name for markdown (default, grace, simple, modern). Default: default
   --color <name|hex>  Primary color (blue, green, vermilion, etc. or hex)
   --cover <path>      Cover image path (local or URL)
@@ -500,6 +503,7 @@ Frontmatter Fields (markdown):
   title               Article title
   author              Author name
   digest/summary      Article summary
+  sourceUrl/contentSourceUrl/content_source_url   Original article URL
   coverImage/featureImage/cover/image   Cover image path
 
 Comments:
@@ -517,7 +521,7 @@ Config File Locations (in priority order):
 Example:
   npx -y bun wechat-api.ts article.md
   npx -y bun wechat-api.ts article.md --theme grace --cover cover.png
-  npx -y bun wechat-api.ts article.md --author "Author Name" --summary "Brief intro"
+  npx -y bun wechat-api.ts article.md --author "Author Name" --summary "Brief intro" --source-url "https://example.com/original"
   npx -y bun wechat-api.ts article.html --title "My Article"
   npx -y bun wechat-api.ts images/ --type newspic --title "Photo Album"
   npx -y bun wechat-api.ts article.md --dry-run
@@ -533,6 +537,7 @@ interface CliArgs {
   title?: string;
   author?: string;
   summary?: string;
+  sourceUrl?: string;
   theme: string;
   color?: string;
   cover?: string;
@@ -578,6 +583,8 @@ function parseArgs(argv: string[]): CliArgs {
       args.author = argv[++i];
     } else if (arg === "--summary" && argv[i + 1]) {
       args.summary = argv[++i];
+    } else if (arg === "--source-url" && argv[i + 1]) {
+      args.sourceUrl = argv[++i];
     } else if (arg === "--theme" && argv[i + 1]) {
       args.theme = argv[++i]!;
     } else if (arg === "--color" && argv[i + 1]) {
@@ -692,6 +699,7 @@ async function main(): Promise<void> {
   let title = args.title || "";
   let author = args.author || "";
   let digest = args.summary || "";
+  let sourceUrl = args.sourceUrl || "";
   let htmlPath: string;
   let htmlContent: string;
   let frontmatter: Record<string, string> = {};
@@ -708,6 +716,7 @@ async function main(): Promise<void> {
       if (!title && frontmatter.title) title = frontmatter.title;
       if (!author) author = frontmatter.author || "";
       if (!digest) digest = frontmatter.digest || frontmatter.summary || frontmatter.description || "";
+      if (!sourceUrl) sourceUrl = frontmatter.sourceUrl || frontmatter.contentSourceUrl || frontmatter.content_source_url || "";
     }
     if (!title) {
       title = extractHtmlTitle(fs.readFileSync(htmlPath, "utf-8"));
@@ -726,6 +735,7 @@ async function main(): Promise<void> {
     }
     if (!author) author = frontmatter.author || "";
     if (!digest) digest = frontmatter.digest || frontmatter.summary || frontmatter.description || "";
+    if (!sourceUrl) sourceUrl = frontmatter.sourceUrl || frontmatter.contentSourceUrl || frontmatter.content_source_url || "";
 
     console.error(`[wechat-api] Theme: ${args.theme}${args.color ? `, color: ${args.color}` : ""}, citeStatus: ${args.citeStatus}`);
     const rendered = renderMarkdownWithPlaceholders(filePath, args.theme, args.color, args.citeStatus, args.title);
@@ -754,6 +764,7 @@ async function main(): Promise<void> {
   console.error(`[wechat-api] Title: ${title}`);
   if (author) console.error(`[wechat-api] Author: ${author}`);
   if (digest) console.error(`[wechat-api] Digest: ${digest.slice(0, 50)}...`);
+  if (sourceUrl) console.error(`[wechat-api] Source URL: ${sourceUrl}`);
   console.error(`[wechat-api] Type: ${args.articleType}`);
 
   const extConfig = loadWechatExtendConfig();
@@ -768,6 +779,7 @@ async function main(): Promise<void> {
       title,
       author: author || undefined,
       digest: digest || undefined,
+      sourceUrl: sourceUrl || undefined,
       htmlPath,
       contentLength: htmlContent.length,
       placeholderImageCount: contentImages.length || undefined,
@@ -839,6 +851,7 @@ async function main(): Promise<void> {
       content: htmlContent,
       thumbMediaId,
       articleType: args.articleType,
+      contentSourceUrl: sourceUrl || undefined,
       imageMediaIds: args.articleType === "newspic" ? imageMediaIds : undefined,
       needOpenComment: resolved.need_open_comment,
       onlyFansCanComment: resolved.only_fans_can_comment,


### PR DESCRIPTION
## Summary

Add the ability to specify the **original article URL** ("阅读原文" link) when publishing to WeChat Official Account draft via the API method. This maps to the `content_source_url` field in WeChat's `draft/add` API.

### Motivation

When using the CLI to publish articles to the WeChat draft box, there was no way to set the "阅读原文" (Read Original) link. Users had to manually add it in the WeChat editor after the draft was created. This PR enables passing the source URL directly through the CLI or markdown frontmatter.

### Changes

| File | Change |
|------|--------|
| `scripts/wechat-api.ts` | Add `contentSourceUrl` to `ArticleOptions` interface, write `content_source_url` in `publishToDraft` for `news` articles, add `--source-url` CLI parameter, extract from frontmatter (`sourceUrl`/`contentSourceUrl`/`content_source_url`), update help text |
| `SKILL.md` | Document `--source-url` in API method usage, add `content_source_url` to draft/add payload rules, add Source URL row in Step 3 metadata table |

### WeChat API Reference

Per the official [`draft/add`](https://developers.weixin.qq.com/doc/subscription/api/draftbox/draftmanage/api_draft_add.html) API documentation:

- `content_source_url` (string, optional): 图文消息的原文地址，大小不可超过1KB，即点击"阅读原文"后的URL
- Only applicable for `article_type=news` (图文消息), not `newspic` (图片消息)
- This field was last updated in the official docs on 2025-12-19

### Usage

**CLI:**
```bash
npx -y bun wechat-api.ts article.md --source-url "https://example.com/original"
```

**Markdown frontmatter:**
```markdown
---
title: My Article
sourceUrl: https://example.com/original
---
```

The `contentSourceUrl` and `content_source_url` frontmatter keys are also accepted.

**Priority:** CLI `--source-url` → frontmatter → (not set)

### Design Decisions

1. **API-only, not browser method**: The browser-based publishing flow (`wechat-article.ts`) is not modified. WeChat's editor already provides a native "原文链接" input field that browser users can fill manually. Adding CDP automation for this field would add complexity and fragility (WeChat's UI may change).

2. **Conditional field write**: `content_source_url` is only included in the API payload when a value is provided, following the same pattern as `author` and `digest`.

3. **Multiple frontmatter keys**: Supports `sourceUrl`, `contentSourceUrl`, and `content_source_url` to accommodate different naming conventions, consistent with the existing multi-alias pattern for cover images (`coverImage`/`featureImage`/`cover`/`image`).

4. **news type only**: Per WeChat API spec, `content_source_url` is only valid for `article_type=news`. The code only writes this field in the `news` branch of `publishToDraft`.

### Testing

- Existing tests pass (14/14 for `wechat-http.test.ts` and `wechat-extend-config.test.ts`)
- `--help` output verified to include `--source-url` and frontmatter documentation
- `--dry-run` output includes `sourceUrl` when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)