### PR TITLE
feat(baoyu-image-gen): add Agnes provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ English | [中文](./CHANGELOG.zh.md)
 ## Unreleased
 
 ### Features
-- `baoyu-image-gen`: add a first-class Agnes provider (`--provider agnes`) for `agnes-image-2.1-flash`, including text-to-image, image-to-image via `--ref`, model/env/config wiring (`AGNES_API_KEY`, `AGNES_IMAGE_MODEL`, `AGNES_BASE_URL`), provider auto-detection, batch rate-limit overrides, tests, and docs
+- `baoyu-image-gen`: add a first-class Agnes provider (`--provider agnes`) for `agnes-image-2.1-flash`, including text-to-image, image-to-image via `--ref`, URL-output mode via `--response-format url`, model/env/config wiring (`AGNES_API_KEY`, `AGNES_IMAGE_MODEL`, `AGNES_BASE_URL`), provider auto-detection, batch rate-limit overrides, tests, and docs
 
 ## 2.4.1 - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 English | [中文](./CHANGELOG.zh.md)
 
+## Unreleased
+
+### Features
+- `baoyu-image-gen`: add a first-class Agnes provider (`--provider agnes`) for `agnes-image-2.1-flash`, including text-to-image, image-to-image via `--ref`, model/env/config wiring (`AGNES_API_KEY`, `AGNES_IMAGE_MODEL`, `AGNES_BASE_URL`), provider auto-detection, batch rate-limit overrides, tests, and docs
+
 ## 2.4.1 - 2026-06-01
 
 ### Fixes

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -2,6 +2,11 @@
 
 [English](./CHANGELOG.md) | 中文
 
+## Unreleased
+
+### 新功能
+- `baoyu-image-gen`：新增一等 Agnes provider（`--provider agnes`），适配 `agnes-image-2.1-flash`。支持文生图、通过 `--ref` 的图生图、通过 `--response-format url` 输出 URL、`AGNES_API_KEY` / `AGNES_IMAGE_MODEL` / `AGNES_BASE_URL` 配置、provider 自动识别、batch 限流覆盖，以及配套测试与文档
+
 ## 2.4.1 - 2026-06-01
 
 ### 修复

--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ AI-powered generation backends.
 
 #### baoyu-image-gen
 
-AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, OpenRouter, DashScope (Aliyun Tongyi Wanxiang), MiniMax, Jimeng (即梦), Seedream (豆包), and Replicate APIs. Supports text-to-image, reference images, aspect ratios, custom sizes, batch generation, and quality presets.
+AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Agnes, OpenRouter, DashScope (Aliyun Tongyi Wanxiang), MiniMax, Jimeng (即梦), Seedream (豆包), and Replicate APIs. Supports text-to-image, reference images, aspect ratios, custom sizes, batch generation, and quality presets.
 
 ```bash
 # Basic generation (auto-detect provider)
@@ -745,6 +745,12 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 
 # Azure OpenAI (model = deployment name)
 /baoyu-image-gen --prompt "A cat" --image cat.png --provider azure --model gpt-image-2
+
+# Agnes Image 2.1 Flash
+/baoyu-image-gen --prompt "A cat" --image cat.png --provider agnes
+
+# Agnes with reference image edit
+/baoyu-image-gen --prompt "Make it blue while preserving the composition" --image out.png --provider agnes --ref source.png
 
 # OpenRouter
 /baoyu-image-gen --prompt "A cat" --image cat.png --provider openrouter
@@ -782,7 +788,7 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 # Seedream (豆包)
 /baoyu-image-gen --prompt "一只可爱的猫" --image cat.png --provider seedream
 
-# With reference images (Google, OpenAI, Azure OpenAI, OpenRouter, Replicate, MiniMax, or Seedream 5.0/4.5/4.0)
+# With reference images (Google, OpenAI, Agnes, Azure OpenAI, OpenRouter, Replicate, MiniMax, or Seedream 5.0/4.5/4.0)
 /baoyu-image-gen --prompt "Make it blue" --image out.png --ref source.png
 
 # Batch mode
@@ -797,14 +803,14 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 | `--image` | Output image path (required) |
 | `--batchfile` | JSON batch file for multi-image generation |
 | `--jobs` | Worker count for batch mode |
-| `--provider` | `google`, `openai`, `azure`, `openrouter`, `dashscope`, `zai`, `minimax`, `jimeng`, `seedream`, or `replicate` |
+| `--provider` | `google`, `openai`, `agnes`, `azure`, `openrouter`, `dashscope`, `zai`, `minimax`, `jimeng`, `seedream`, or `replicate` |
 | `--model`, `-m` | Model ID or deployment name. Azure uses deployment name; OpenRouter uses full model IDs; Z.AI uses `glm-image`; MiniMax uses `image-01` / `image-01-live` |
 | `--ar` | Aspect ratio (e.g., `16:9`, `1:1`, `4:3`) |
 | `--size` | Size (e.g., `1024x1024`; `gpt-image-2` accepts valid custom sizes up to 3840px max edge) |
 | `--quality` | `normal` or `2k` (default: `2k`) |
 | `--imageSize` | `1K`, `2K`, or `4K` for Google/OpenRouter |
 | `--imageApiDialect` | `openai-native` or `ratio-metadata` for OpenAI-compatible gateways |
-| `--ref` | Reference images (Google, OpenAI, Azure OpenAI, OpenRouter, Replicate supported families, MiniMax, or Seedream 5.0/4.5/4.0) |
+| `--ref` | Reference images (Google, OpenAI, Agnes, Azure OpenAI, OpenRouter, Replicate supported families, MiniMax, or Seedream 5.0/4.5/4.0) |
 | `--n` | Number of images per request (`replicate` currently requires `--n 1`) |
 | `--json` | JSON output |
 
@@ -812,6 +818,7 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `OPENAI_API_KEY` | OpenAI API key | - |
+| `AGNES_API_KEY` | Agnes API key | - |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API key | - |
 | `OPENROUTER_API_KEY` | OpenRouter API key | - |
 | `GOOGLE_API_KEY` | Google API key | - |
@@ -825,6 +832,7 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 | `JIMENG_SECRET_ACCESS_KEY` | Jimeng Volcengine secret key | - |
 | `ARK_API_KEY` | Seedream Volcengine ARK API key | - |
 | `OPENAI_IMAGE_MODEL` | OpenAI model | `gpt-image-2` |
+| `AGNES_IMAGE_MODEL` | Agnes model | `agnes-image-2.1-flash` |
 | `AZURE_OPENAI_DEPLOYMENT` | Azure default deployment name | - |
 | `AZURE_OPENAI_IMAGE_MODEL` | Backward-compatible Azure deployment/model alias | `gpt-image-2` |
 | `OPENROUTER_IMAGE_MODEL` | OpenRouter model | `google/gemini-3.1-flash-image` |
@@ -837,6 +845,7 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 | `JIMENG_IMAGE_MODEL` | Jimeng model | `jimeng_t2i_v40` |
 | `SEEDREAM_IMAGE_MODEL` | Seedream model | `doubao-seedream-5-0-260128` |
 | `OPENAI_BASE_URL` | Custom OpenAI endpoint | - |
+| `AGNES_BASE_URL` | Custom Agnes endpoint | `https://apihub.agnes-ai.com/v1` |
 | `OPENAI_IMAGE_API_DIALECT` | OpenAI-compatible image API dialect (`openai-native` or `ratio-metadata`) | `openai-native` |
 | `OPENAI_IMAGE_USE_CHAT` | Use `/chat/completions` for OpenAI image generation | `false` |
 | `AZURE_OPENAI_BASE_URL` | Azure resource or deployment endpoint | - |
@@ -859,6 +868,7 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 
 **Provider Notes**:
 - Azure OpenAI: `--model` means Azure deployment name, not the underlying model family.
+- Agnes: `agnes-image-2.1-flash` supports both text-to-image and image-to-image. baoyu-image-gen requests Base64 output and sends reference images as Data URLs (or public HTTPS URLs when you pass them directly).
 - DashScope: `qwen-image-2.0-pro` is the recommended default for custom `--size`, `21:9`, and strong Chinese/English text rendering.
 - Z.AI: `glm-image` is recommended for posters, diagrams, and text-heavy Chinese/English images. Reference images are not supported.
 - MiniMax: `image-01` supports documented custom `width` / `height`; `image-01-live` is lower latency and works best with `--ar`.
@@ -871,9 +881,9 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Op
 
 **Provider Auto-Selection**:
 1. If `--provider` is specified → use it
-2. If `--ref` is provided and no provider is specified → try Google, then OpenAI, Azure, OpenRouter, Replicate, Seedream, and finally MiniMax
+2. If `--ref` is provided and no provider is specified → try Google, then OpenAI, Agnes, Azure, OpenRouter, Replicate, Seedream, and finally MiniMax
 3. If only one API key is available → use that provider
-4. If multiple providers are available → default to Google, then OpenAI, Azure, OpenRouter, DashScope, Z.AI, MiniMax, Replicate, Jimeng, Seedream
+4. If multiple providers are available → default to Google, then OpenAI, Agnes, Azure, OpenRouter, DashScope, Z.AI, MiniMax, Replicate, Jimeng, Seedream
 
 #### baoyu-danger-gemini-web
 

--- a/README.md
+++ b/README.md
@@ -752,6 +752,9 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Ag
 # Agnes with reference image edit
 /baoyu-image-gen --prompt "Make it blue while preserving the composition" --image out.png --provider agnes --ref source.png
 
+# Agnes URL output (writes the returned image URL into a .txt file)
+/baoyu-image-gen --prompt "A cat" --image cat-url.txt --provider agnes --response-format url
+
 # OpenRouter
 /baoyu-image-gen --prompt "A cat" --image cat.png --provider openrouter
 
@@ -810,6 +813,7 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Ag
 | `--quality` | `normal` or `2k` (default: `2k`) |
 | `--imageSize` | `1K`, `2K`, or `4K` for Google/OpenRouter |
 | `--imageApiDialect` | `openai-native` or `ratio-metadata` for OpenAI-compatible gateways |
+| `--response-format` | Agnes only: `file` (default) or `url` |
 | `--ref` | Reference images (Google, OpenAI, Agnes, Azure OpenAI, OpenRouter, Replicate supported families, MiniMax, or Seedream 5.0/4.5/4.0) |
 | `--n` | Number of images per request (`replicate` currently requires `--n 1`) |
 | `--json` | JSON output |
@@ -868,7 +872,7 @@ AI SDK-based image generation using OpenAI GPT Image 2, Azure OpenAI, Google, Ag
 
 **Provider Notes**:
 - Azure OpenAI: `--model` means Azure deployment name, not the underlying model family.
-- Agnes: `agnes-image-2.1-flash` supports both text-to-image and image-to-image. baoyu-image-gen requests Base64 output and sends reference images as Data URLs (or public HTTPS URLs when you pass them directly).
+- Agnes: `agnes-image-2.1-flash` supports both text-to-image and image-to-image. baoyu-image-gen uses top-level `return_base64: true` for default text-to-image output, sends image-to-image refs via `extra_body.image[]`, accepts local refs or public HTTPS refs, and supports `--response-format url` to write the returned URL into a `.txt` file.
 - DashScope: `qwen-image-2.0-pro` is the recommended default for custom `--size`, `21:9`, and strong Chinese/English text rendering.
 - Z.AI: `glm-image` is recommended for posters, diagrams, and text-heavy Chinese/English images. Reference images are not supported.
 - MiniMax: `image-01` supports documented custom `width` / `height`; `image-01-live` is lower latency and works best with `--ar`.

--- a/README.zh.md
+++ b/README.zh.md
@@ -747,6 +747,15 @@ AI 驱动的生成后端。
 # Azure OpenAI（model 为部署名称）
 /baoyu-image-gen --prompt "一只猫" --image cat.png --provider azure --model gpt-image-2
 
+# Agnes Image 2.1 Flash
+/baoyu-image-gen --prompt "一只猫" --image cat.png --provider agnes
+
+# Agnes + 参考图编辑
+/baoyu-image-gen --prompt "把它变成蓝色，同时保留原始构图" --image out.png --provider agnes --ref source.png
+
+# Agnes URL 输出（把返回的图片 URL 写入 .txt 文件）
+/baoyu-image-gen --prompt "一只猫" --image cat-url.txt --provider agnes --response-format url
+
 # OpenRouter
 /baoyu-image-gen --prompt "一只猫" --image cat.png --provider openrouter
 
@@ -783,7 +792,7 @@ AI 驱动的生成后端。
 # 豆包（Seedream）
 /baoyu-image-gen --prompt "一只可爱的猫" --image cat.png --provider seedream
 
-# 带参考图（Google、OpenAI、Azure OpenAI、OpenRouter、Replicate、MiniMax 或 Seedream 5.0/4.5/4.0）
+# 带参考图（Google、OpenAI、Agnes、Azure OpenAI、OpenRouter、Replicate、MiniMax 或 Seedream 5.0/4.5/4.0）
 /baoyu-image-gen --prompt "把它变成蓝色" --image out.png --ref source.png
 
 # 批量模式
@@ -798,14 +807,15 @@ AI 驱动的生成后端。
 | `--image` | 输出图片路径（必需） |
 | `--batchfile` | 多图批量生成的 JSON 文件 |
 | `--jobs` | 批量模式的并发 worker 数 |
-| `--provider` | `google`、`openai`、`azure`、`openrouter`、`dashscope`、`zai`、`minimax`、`jimeng`、`seedream` 或 `replicate` |
+| `--provider` | `google`、`openai`、`agnes`、`azure`、`openrouter`、`dashscope`、`zai`、`minimax`、`jimeng`、`seedream` 或 `replicate` |
 | `--model`, `-m` | 模型 ID 或部署名。Azure 使用部署名；OpenRouter 使用完整模型 ID；Z.AI 使用 `glm-image`；MiniMax 使用 `image-01` / `image-01-live` |
 | `--ar` | 宽高比（如 `16:9`、`1:1`、`4:3`） |
 | `--size` | 尺寸（如 `1024x1024`；`gpt-image-2` 支持最长边不超过 3840px 的有效自定义尺寸） |
 | `--quality` | `normal` 或 `2k`（默认：`2k`） |
 | `--imageSize` | Google/OpenRouter 使用的 `1K`、`2K`、`4K` |
 | `--imageApiDialect` | OpenAI 兼容网关的图像 API 方言（`openai-native` 或 `ratio-metadata`） |
-| `--ref` | 参考图片（Google、OpenAI、Azure OpenAI、OpenRouter、Replicate 支持的模型家族、MiniMax 或 Seedream 5.0/4.5/4.0） |
+| `--response-format` | 仅 Agnes：`file`（默认）或 `url` |
+| `--ref` | 参考图片（Google、OpenAI、Agnes、Azure OpenAI、OpenRouter、Replicate 支持的模型家族、MiniMax 或 Seedream 5.0/4.5/4.0） |
 | `--n` | 单次请求生成图片数量（`replicate` 当前只支持 `--n 1`） |
 | `--json` | 输出 JSON 结果 |
 
@@ -813,6 +823,7 @@ AI 驱动的生成后端。
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
 | `OPENAI_API_KEY` | OpenAI API 密钥 | - |
+| `AGNES_API_KEY` | Agnes API 密钥 | - |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API 密钥 | - |
 | `OPENROUTER_API_KEY` | OpenRouter API 密钥 | - |
 | `GOOGLE_API_KEY` | Google API 密钥 | - |
@@ -826,6 +837,7 @@ AI 驱动的生成后端。
 | `JIMENG_SECRET_ACCESS_KEY` | 即梦火山引擎 Secret Key | - |
 | `ARK_API_KEY` | 豆包火山引擎 ARK API 密钥 | - |
 | `OPENAI_IMAGE_MODEL` | OpenAI 模型 | `gpt-image-2` |
+| `AGNES_IMAGE_MODEL` | Agnes 模型 | `agnes-image-2.1-flash` |
 | `AZURE_OPENAI_DEPLOYMENT` | Azure 默认部署名 | - |
 | `AZURE_OPENAI_IMAGE_MODEL` | 兼容旧配置的 Azure 部署/模型别名 | `gpt-image-2` |
 | `OPENROUTER_IMAGE_MODEL` | OpenRouter 模型 | `google/gemini-3.1-flash-image` |
@@ -838,6 +850,7 @@ AI 驱动的生成后端。
 | `JIMENG_IMAGE_MODEL` | 即梦模型 | `jimeng_t2i_v40` |
 | `SEEDREAM_IMAGE_MODEL` | 豆包模型 | `doubao-seedream-5-0-260128` |
 | `OPENAI_BASE_URL` | 自定义 OpenAI 端点 | - |
+| `AGNES_BASE_URL` | 自定义 Agnes 端点 | `https://apihub.agnes-ai.com/v1` |
 | `OPENAI_IMAGE_API_DIALECT` | OpenAI 兼容图像 API 方言（`openai-native` 或 `ratio-metadata`） | `openai-native` |
 | `OPENAI_IMAGE_USE_CHAT` | OpenAI 改走 `/chat/completions` | `false` |
 | `AZURE_OPENAI_BASE_URL` | Azure 资源或部署端点 | - |
@@ -860,6 +873,7 @@ AI 驱动的生成后端。
 
 **Provider 说明**：
 - Azure OpenAI：`--model` 表示 Azure deployment name，不是底层模型家族名。
+- Agnes：`agnes-image-2.1-flash` 同时支持文生图和图生图。默认文生图走顶层 `return_base64: true`；图生图参考图走 `extra_body.image[]`；本地文件和公开 HTTPS 参考图都支持；传 `--response-format url` 时会把返回 URL 写入 `.txt` 文件。
 - DashScope：`qwen-image-2.0-pro` 是自定义 `--size`、`21:9` 和中英文排版的推荐默认模型。
 - Z.AI：`glm-image` 适合海报、图表和中英文排版密集的图片生成，暂不支持参考图。
 - MiniMax：`image-01` 支持官方文档里的自定义 `width` / `height`；`image-01-live` 更偏低延迟，适合配合 `--ar` 使用。
@@ -872,9 +886,9 @@ AI 驱动的生成后端。
 
 **服务商自动选择**：
 1. 如果指定了 `--provider` → 使用指定的
-2. 如果传了 `--ref` 且未指定 provider → 依次尝试 Google、OpenAI、Azure、OpenRouter、Replicate、Seedream，最后是 MiniMax
+2. 如果传了 `--ref` 且未指定 provider → 依次尝试 Google、OpenAI、Agnes、Azure、OpenRouter、Replicate、Seedream，最后是 MiniMax
 3. 如果只有一个 API 密钥 → 使用对应服务商
-4. 如果多个可用 → 默认使用 Google，然后依次为 OpenAI、Azure、OpenRouter、DashScope、Z.AI、MiniMax、Replicate、即梦、豆包
+4. 如果多个可用 → 默认使用 Google，然后依次为 OpenAI、Agnes、Azure、OpenRouter、DashScope、Z.AI、MiniMax、Replicate、即梦、豆包
 
 #### baoyu-danger-gemini-web
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "pdf-lib": "^1.17.1",
         "pptxgenjs": "^4.0.1",
-        "sharp": "^0.34.5"
+        "sharp": "^0.34.5",
+        "socks": "^2.8.9"
       },
       "devDependencies": {
         "@mozilla/readability": "^0.6.0",
@@ -2632,6 +2633,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -4523,6 +4533,30 @@
       "license": "MIT (http://mootools.net/license.txt)",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,15 @@
   "devDependencies": {
     "@mozilla/readability": "^0.6.0",
     "linkedom": "^0.18.12",
+    "tsx": "^4.20.5",
     "turndown": "^7.2.2",
-    "turndown-plugin-gfm": "^1.0.2",
-    "tsx": "^4.20.5"
+    "turndown-plugin-gfm": "^1.0.2"
   },
   "dependencies": {
     "pdf-lib": "^1.17.1",
     "pptxgenjs": "^4.0.1",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "socks": "^2.8.9"
   },
   "overrides": {
     "@xmldom/xmldom": "0.8.13"

--- a/skills/baoyu-image-gen/SKILL.md
+++ b/skills/baoyu-image-gen/SKILL.md
@@ -84,6 +84,9 @@ ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider o
 # Agnes Image 2.1 Flash
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider agnes
 
+# Agnes URL output (writes the returned image URL into a .txt file)
+${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.txt --provider agnes --response-format url
+
 # Codex CLI (uses logged-in Codex subscription — no OPENAI_API_KEY required; requires `codex` on PATH)
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider codex-cli --ar 16:9
 
@@ -121,6 +124,7 @@ When the user wants a person/object preserved from reference images:
 | `--quality normal\|2k` | Quality preset (default: `2k`) |
 | `--imageSize 1K\|2K\|4K` | Image size for Google/OpenRouter (default: from quality) |
 | `--imageApiDialect openai-native\|ratio-metadata` | OpenAI-compatible endpoint dialect — use `ratio-metadata` for gateways that expect aspect-ratio `size` plus `metadata.resolution` |
+| `--response-format file\|url` | Agnes only. `file` (default) saves the image bytes; `url` writes the returned image URL into a `.txt` file |
 | `--ref <files...>` | Reference images. Supported by Google multimodal, OpenAI GPT Image edits, Agnes image-to-image, Azure OpenAI edits (PNG/JPG only), OpenRouter multimodal models, Replicate supported families, MiniMax subject-reference, Seedream 5.0/4.5/4.0, DashScope `wan2.7-image-pro`/`wan2.7-image`. Not supported by Jimeng, Seedream 3.0, SeedEdit 3.0, or any DashScope model outside the `wan2.7-image*` family |
 | `--n <count>` | Number of images. Replicate requires `--n 1` (single-output save semantics) |
 | `--json` | JSON output |

--- a/skills/baoyu-image-gen/SKILL.md
+++ b/skills/baoyu-image-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: baoyu-image-gen
-description: AI image generation with OpenAI GPT Image 2, Azure OpenAI, Google, OpenRouter, DashScope, Z.AI GLM-Image, MiniMax, Jimeng, Seedream and Replicate APIs. Supports text-to-image, reference images, aspect ratios, and batch generation from saved prompt files. Sequential by default; use batch parallel generation when the user already has multiple prompts or wants stable multi-image throughput. Use when user asks to generate, create, or draw images.
+description: AI image generation with OpenAI GPT Image 2, Azure OpenAI, Google, Agnes, OpenRouter, DashScope, Z.AI GLM-Image, MiniMax, Jimeng, Seedream and Replicate APIs. Supports text-to-image, reference images, aspect ratios, and batch generation from saved prompt files. Sequential by default; use batch parallel generation when the user already has multiple prompts or wants stable multi-image throughput. Use when user asks to generate, create, or draw images.
 version: 2.1.0
 metadata:
   openclaw:
@@ -13,7 +13,7 @@ metadata:
 
 # Image Generation (AI SDK)
 
-Official API-based image generation. Supports OpenAI GPT Image 2, Azure OpenAI, Google, OpenRouter, DashScope (阿里通义万象), Z.AI GLM-Image, MiniMax, Jimeng (即梦), Seedream (豆包) and Replicate.
+Official API-based image generation. Supports OpenAI GPT Image 2, Azure OpenAI, Google, Agnes, OpenRouter, DashScope (阿里通义万象), Z.AI GLM-Image, MiniMax, Jimeng (即梦), Seedream (豆包) and Replicate.
 
 ## User Input Tools
 
@@ -81,6 +81,9 @@ ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider d
 # OpenAI GPT Image 2
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider openai --model gpt-image-2
 
+# Agnes Image 2.1 Flash
+${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider agnes
+
 # Codex CLI (uses logged-in Codex subscription — no OPENAI_API_KEY required; requires `codex` on PATH)
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider codex-cli --ar 16:9
 
@@ -111,14 +114,14 @@ When the user wants a person/object preserved from reference images:
 | `--image <path>` | Output image path (required in single-image mode) |
 | `--batchfile <path>` | JSON batch file for multi-image generation |
 | `--jobs <count>` | Worker count for batch mode (default: auto, max from config, built-in default 10) |
-| `--provider google\|openai\|azure\|openrouter\|dashscope\|zai\|minimax\|jimeng\|seedream\|replicate\|codex-cli` | Force provider (default: auto-detect; `codex-cli` is never auto-selected — must be pinned via CLI or EXTEND.md) |
+| `--provider google\|openai\|agnes\|azure\|openrouter\|dashscope\|zai\|minimax\|jimeng\|seedream\|replicate\|codex-cli` | Force provider (default: auto-detect; `codex-cli` is never auto-selected — must be pinned via CLI or EXTEND.md) |
 | `--model <id>`, `-m` | Model ID — see provider references for defaults and allowed values |
 | `--ar <ratio>` | Aspect ratio (`16:9`, `1:1`, `4:3`, …) |
 | `--size <WxH>` | Explicit size (e.g., `1024x1024`; for `gpt-image-2`, width/height must be multiples of 16, max edge 3840px, ratio no wider than 3:1) |
 | `--quality normal\|2k` | Quality preset (default: `2k`) |
 | `--imageSize 1K\|2K\|4K` | Image size for Google/OpenRouter (default: from quality) |
 | `--imageApiDialect openai-native\|ratio-metadata` | OpenAI-compatible endpoint dialect — use `ratio-metadata` for gateways that expect aspect-ratio `size` plus `metadata.resolution` |
-| `--ref <files...>` | Reference images. Supported by Google multimodal, OpenAI GPT Image edits, Azure OpenAI edits (PNG/JPG only), OpenRouter multimodal models, Replicate supported families, MiniMax subject-reference, Seedream 5.0/4.5/4.0, DashScope `wan2.7-image-pro`/`wan2.7-image`. Not supported by Jimeng, Seedream 3.0, SeedEdit 3.0, or any DashScope model outside the `wan2.7-image*` family |
+| `--ref <files...>` | Reference images. Supported by Google multimodal, OpenAI GPT Image edits, Agnes image-to-image, Azure OpenAI edits (PNG/JPG only), OpenRouter multimodal models, Replicate supported families, MiniMax subject-reference, Seedream 5.0/4.5/4.0, DashScope `wan2.7-image-pro`/`wan2.7-image`. Not supported by Jimeng, Seedream 3.0, SeedEdit 3.0, or any DashScope model outside the `wan2.7-image*` family |
 | `--n <count>` | Number of images. Replicate requires `--n 1` (single-output save semantics) |
 | `--json` | JSON output |
 
@@ -127,6 +130,7 @@ When the user wants a person/object preserved from reference images:
 | Variable | Description |
 |----------|-------------|
 | `OPENAI_API_KEY` | OpenAI API key |
+| `AGNES_API_KEY` | Agnes API key |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API key |
 | `OPENROUTER_API_KEY` | OpenRouter API key |
 | `GOOGLE_API_KEY` | Google API key |
@@ -136,8 +140,9 @@ When the user wants a person/object preserved from reference images:
 | `REPLICATE_API_TOKEN` | Replicate API token |
 | `JIMENG_ACCESS_KEY_ID`, `JIMENG_SECRET_ACCESS_KEY` | Jimeng (即梦) Volcengine credentials |
 | `ARK_API_KEY` | Seedream (豆包) Volcengine ARK API key |
-| `<PROVIDER>_IMAGE_MODEL` | Per-provider model override (`OPENAI_IMAGE_MODEL`, `GOOGLE_IMAGE_MODEL`, `DASHSCOPE_IMAGE_MODEL`, `ZAI_IMAGE_MODEL`/`BIGMODEL_IMAGE_MODEL`, `MINIMAX_IMAGE_MODEL`, `OPENROUTER_IMAGE_MODEL`, `REPLICATE_IMAGE_MODEL`, `JIMENG_IMAGE_MODEL`, `SEEDREAM_IMAGE_MODEL`) |
+| `<PROVIDER>_IMAGE_MODEL` | Per-provider model override (`OPENAI_IMAGE_MODEL`, `AGNES_IMAGE_MODEL`, `GOOGLE_IMAGE_MODEL`, `DASHSCOPE_IMAGE_MODEL`, `ZAI_IMAGE_MODEL`/`BIGMODEL_IMAGE_MODEL`, `MINIMAX_IMAGE_MODEL`, `OPENROUTER_IMAGE_MODEL`, `REPLICATE_IMAGE_MODEL`, `JIMENG_IMAGE_MODEL`, `SEEDREAM_IMAGE_MODEL`) |
 | `AZURE_OPENAI_DEPLOYMENT` (alias `AZURE_OPENAI_IMAGE_MODEL`) | Azure default deployment |
+| `AGNES_BASE_URL` | Agnes API base URL or full `/images/generations` endpoint (default `https://apihub.agnes-ai.com/v1`) |
 | `<PROVIDER>_BASE_URL` | Per-provider endpoint override |
 | `AZURE_API_VERSION` | Azure image API version (default `2025-04-01-preview`) |
 | `JIMENG_REGION` | Jimeng region (default `cn-north-1`) |
@@ -201,6 +206,7 @@ Each provider has its own quirks (model families, size rules, ref support, limit
 
 | Provider | Reference |
 |----------|-----------|
+| Agnes Image 2.1 Flash | `references/providers/agnes.md` |
 | DashScope (Qwen-Image families, custom sizes) | `references/providers/dashscope.md` |
 | Z.AI (GLM-Image, cogview-4) | `references/providers/zai.md` |
 | MiniMax (image-01, subject-reference) | `references/providers/minimax.md` |
@@ -210,10 +216,10 @@ Each provider has its own quirks (model families, size rules, ref support, limit
 
 ## Provider Selection
 
-1. `--ref` provided + no `--provider` → auto-select Google → OpenAI → Azure → OpenRouter → Replicate → Seedream → MiniMax (MiniMax's subject reference is more specialized toward character/portrait consistency)
-2. `--provider` specified → use it (if `--ref`, must be google/openai/azure/openrouter/replicate/seedream/minimax/codex-cli)
+1. `--ref` provided + no `--provider` → auto-select Google → OpenAI → Agnes → Azure → OpenRouter → Replicate → Seedream → MiniMax (MiniMax's subject reference is more specialized toward character/portrait consistency)
+2. `--provider` specified → use it (if `--ref`, must be google/openai/agnes/azure/openrouter/replicate/seedream/minimax/dashscope/codex-cli)
 3. Only one API key present → use that provider
-4. Multiple keys → default priority: Google → OpenAI → Azure → OpenRouter → DashScope → Z.AI → MiniMax → Replicate → Jimeng → Seedream
+4. Multiple keys → default priority: Google → OpenAI → Agnes → Azure → OpenRouter → DashScope → Z.AI → MiniMax → Replicate → Jimeng → Seedream
 5. `codex-cli` is **never auto-selected** — set `default_provider: codex-cli` in EXTEND.md or pass `--provider codex-cli`. It spawns `codex exec` via the bundled `scripts/codex-imagegen/main.ts` TS entrypoint (run with `bun`) and uses the user's Codex subscription (no `OPENAI_API_KEY`). Requires `codex` on `PATH` with an active `codex login`.
 
 ## Quality Presets

--- a/skills/baoyu-image-gen/references/config/preferences-schema.md
+++ b/skills/baoyu-image-gen/references/config/preferences-schema.md
@@ -11,7 +11,7 @@ description: EXTEND.md YAML schema for baoyu-image-gen user preferences
 ---
 version: 1
 
-default_provider: null      # google|openai|azure|openrouter|dashscope|zai|minimax|replicate|jimeng|seedream|codex-cli|null (null = auto-detect; codex-cli is never auto-detected — pin it here or via --provider)
+default_provider: null      # google|openai|agnes|azure|openrouter|dashscope|zai|minimax|replicate|jimeng|seedream|codex-cli|null (null = auto-detect; codex-cli is never auto-detected — pin it here or via --provider)
 
 default_quality: null       # normal|2k|null (null = use default: 2k)
 
@@ -24,6 +24,7 @@ default_image_api_dialect: null  # openai-native|ratio-metadata|null (OpenAI-com
 default_model:
   google: null              # e.g., "gemini-3-pro-image", "gemini-3.1-flash-image"
   openai: null              # e.g., "gpt-image-2", "gpt-image-1.5", "gpt-image-1"
+  agnes: null               # e.g., "agnes-image-2.1-flash"
   azure: null               # Azure deployment name, e.g., "gpt-image-2" or "image-prod"
   openrouter: null          # e.g., "google/gemini-3.1-flash-image"
   dashscope: null           # e.g., "qwen-image-2.0-pro"
@@ -42,6 +43,9 @@ batch:
       concurrency: 3
       start_interval_ms: 1100
     openai:
+      concurrency: 3
+      start_interval_ms: 1100
+    agnes:
       concurrency: 3
       start_interval_ms: 1100
     azure:
@@ -77,6 +81,7 @@ batch:
 | `default_image_api_dialect` | string\|null | null | OpenAI-compatible image dialect (`openai-native` or `ratio-metadata`) |
 | `default_model.google` | string\|null | null | Google default model |
 | `default_model.openai` | string\|null | null | OpenAI default model |
+| `default_model.agnes` | string\|null | null | Agnes default model |
 | `default_model.azure` | string\|null | null | Azure default deployment name |
 | `default_model.openrouter` | string\|null | null | OpenRouter default model |
 | `default_model.dashscope` | string\|null | null | DashScope default model |
@@ -112,6 +117,7 @@ default_image_api_dialect: null
 default_model:
   google: "gemini-3-pro-image"
   openai: "gpt-image-2"
+  agnes: "agnes-image-2.1-flash"
   azure: "gpt-image-2"
   openrouter: "google/gemini-3.1-flash-image"
   dashscope: "qwen-image-2.0-pro"
@@ -125,6 +131,9 @@ batch:
       concurrency: 5
       start_interval_ms: 700
     azure:
+      concurrency: 3
+      start_interval_ms: 1100
+    agnes:
       concurrency: 3
       start_interval_ms: 1100
     zai:

--- a/skills/baoyu-image-gen/references/providers/agnes.md
+++ b/skills/baoyu-image-gen/references/providers/agnes.md
@@ -1,0 +1,28 @@
+# Agnes Image 2.1 Flash
+
+Read when the user picks `--provider agnes` or sets `default_model.agnes`. Default model is `agnes-image-2.1-flash`.
+
+## Models
+
+**`agnes-image-2.1-flash`** (recommended default)
+
+- Supports both text-to-image and image-to-image
+- baoyu-image-gen requests Base64 output for text-to-image via top-level `return_base64: true`
+- baoyu-image-gen sends image-to-image refs under `extra_body.image[]` with `extra_body.response_format: "b64_json"` because that path was verified against the live API
+- Local refs are converted to Data URLs; public `https://...` refs are passed through as-is
+
+## Behavior Notes
+
+- Agnes requires an explicit `size` for every request; baoyu-image-gen derives one from `--size`, `--ar`, and `--quality` when you do not pass `--size`
+- `--n > 1` is rejected locally because the current provider flow saves exactly one image per request
+- The API also supports URL output, but baoyu-image-gen prefers Base64 for stability and to avoid an extra download hop where possible
+
+## Environment Variables
+
+- `AGNES_API_KEY`
+- `AGNES_IMAGE_MODEL`
+- `AGNES_BASE_URL`
+
+## Official References
+
+- [Agnes Image 2.1 Flash](https://agnes-ai.com/doc/agnes-image-21-flash)

--- a/skills/baoyu-image-gen/references/providers/agnes.md
+++ b/skills/baoyu-image-gen/references/providers/agnes.md
@@ -10,12 +10,13 @@ Read when the user picks `--provider agnes` or sets `default_model.agnes`. Defau
 - baoyu-image-gen requests Base64 output for text-to-image via top-level `return_base64: true`
 - baoyu-image-gen sends image-to-image refs under `extra_body.image[]` with `extra_body.response_format: "b64_json"` because that path was verified against the live API
 - Local refs are converted to Data URLs; public `https://...` refs are passed through as-is
+- Pass `--response-format url` to request URL output and write the returned URL into a `.txt` file instead of saving image bytes
 
 ## Behavior Notes
 
 - Agnes requires an explicit `size` for every request; baoyu-image-gen derives one from `--size`, `--ar`, and `--quality` when you do not pass `--size`
 - `--n > 1` is rejected locally because the current provider flow saves exactly one image per request
-- The API also supports URL output, but baoyu-image-gen prefers Base64 for stability and to avoid an extra download hop where possible
+- Default behavior prefers Base64 for stability and to avoid an extra download hop where possible
 
 ## Environment Variables
 

--- a/skills/baoyu-image-gen/references/usage-examples.md
+++ b/skills/baoyu-image-gen/references/usage-examples.md
@@ -33,6 +33,9 @@ ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider a
 # Agnes image-to-image with composition preservation
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "Make it blue while preserving the composition" --image out.png --provider agnes --ref source.png
 
+# Agnes URL output
+${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.txt --provider agnes --response-format url
+
 # Azure OpenAI (model = deployment name)
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider azure --model gpt-image-2
 

--- a/skills/baoyu-image-gen/references/usage-examples.md
+++ b/skills/baoyu-image-gen/references/usage-examples.md
@@ -27,6 +27,12 @@ ${BUN_X} {baseDir}/scripts/main.ts --prompt "Make blue" --image out.png --ref so
 # OpenAI
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider openai --model gpt-image-2
 
+# Agnes Image 2.1 Flash
+${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider agnes
+
+# Agnes image-to-image with composition preservation
+${BUN_X} {baseDir}/scripts/main.ts --prompt "Make it blue while preserving the composition" --image out.png --provider agnes --ref source.png
+
 # Azure OpenAI (model = deployment name)
 ${BUN_X} {baseDir}/scripts/main.ts --prompt "A cat" --image out.png --provider azure --model gpt-image-2
 

--- a/skills/baoyu-image-gen/scripts/main.test.ts
+++ b/skills/baoyu-image-gen/scripts/main.test.ts
@@ -36,6 +36,7 @@ function makeArgs(overrides: Partial<CliArgs> = {}): CliArgs {
     imageSize: null,
     imageSizeSource: null,
     imageApiDialect: null,
+    responseFormat: null,
     referenceImages: [],
     n: 1,
     batchFile: null,
@@ -90,6 +91,8 @@ test("parseArgs parses the main baoyu-image-gen CLI flags", () => {
     "4k",
     "--imageApiDialect",
     "ratio-metadata",
+    "--response-format",
+    "url",
     "--ref",
     "ref/one.png",
     "ref/two.jpg",
@@ -108,6 +111,7 @@ test("parseArgs parses the main baoyu-image-gen CLI flags", () => {
   assert.equal(args.imageSize, "4K");
   assert.equal(args.imageSizeSource, "cli");
   assert.equal(args.imageApiDialect, "ratio-metadata");
+  assert.equal(args.responseFormat, "url");
   assert.deepEqual(args.referenceImages, ["ref/one.png", "ref/two.jpg"]);
   assert.equal(args.n, 3);
   assert.equal(args.jobs, 5);
@@ -602,6 +606,7 @@ test("loadBatchTasks and createTaskArgs resolve batch-relative paths", async (t)
       provider: "replicate",
       quality: "2k",
       imageApiDialect: "ratio-metadata",
+      responseFormat: "url",
       json: true,
     }),
     loaded.tasks[0]!,
@@ -620,7 +625,102 @@ test("loadBatchTasks and createTaskArgs resolve batch-relative paths", async (t)
   assert.equal(taskArgs.aspectRatio, "16:9");
   assert.equal(taskArgs.quality, "2k");
   assert.equal(taskArgs.imageApiDialect, "ratio-metadata");
+  assert.equal(taskArgs.responseFormat, "url");
   assert.equal(taskArgs.json, true);
+});
+
+test("prepareSingleTask accepts remote Agnes refs during auto-detection", async (t) => {
+  useEnv(t, {
+    AGNES_API_KEY: "agnes-key",
+    GOOGLE_API_KEY: null,
+    OPENAI_API_KEY: null,
+    AZURE_OPENAI_API_KEY: null,
+    AZURE_OPENAI_BASE_URL: null,
+    OPENROUTER_API_KEY: null,
+    DASHSCOPE_API_KEY: null,
+    ZAI_API_KEY: null,
+    BIGMODEL_API_KEY: null,
+    MINIMAX_API_KEY: null,
+    REPLICATE_API_TOKEN: null,
+    JIMENG_ACCESS_KEY_ID: null,
+    JIMENG_SECRET_ACCESS_KEY: null,
+    ARK_API_KEY: null,
+  });
+
+  const mod = await import("./main.ts");
+  assert.equal(typeof (mod as Record<string, unknown>).prepareSingleTask, "function");
+
+  const prepareSingleTask = (mod as { prepareSingleTask: (args: CliArgs, extend: Partial<ExtendConfig>) => Promise<unknown> }).prepareSingleTask;
+  const prepared = await prepareSingleTask(
+    makeArgs({
+      prompt: "draw a cat",
+      imagePath: "out/agnes-auto-ref",
+      model: "agnes-image-2.1-flash",
+      referenceImages: ["https://example.com/ref.png"],
+    }),
+    {},
+  );
+
+  assert.equal((prepared as { provider: string }).provider, "agnes");
+});
+
+test("prepareBatchTasks accepts remote Agnes refs during auto-detection", async (t) => {
+  useEnv(t, {
+    AGNES_API_KEY: "agnes-key",
+    GOOGLE_API_KEY: null,
+    OPENAI_API_KEY: null,
+    AZURE_OPENAI_API_KEY: null,
+    AZURE_OPENAI_BASE_URL: null,
+    OPENROUTER_API_KEY: null,
+    DASHSCOPE_API_KEY: null,
+    ZAI_API_KEY: null,
+    BIGMODEL_API_KEY: null,
+    MINIMAX_API_KEY: null,
+    REPLICATE_API_TOKEN: null,
+    JIMENG_ACCESS_KEY_ID: null,
+    JIMENG_SECRET_ACCESS_KEY: null,
+    ARK_API_KEY: null,
+  });
+
+  const root = await makeTempDir("baoyu-image-gen-agnes-batch-");
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+
+  const batchFile = path.join(root, "jobs", "batch.json");
+  await fs.mkdir(path.dirname(batchFile), { recursive: true });
+  await fs.writeFile(
+    batchFile,
+    JSON.stringify({
+      tasks: [
+        {
+          id: "agnes-remote-ref",
+          prompt: "make it blue",
+          image: "out/agnes-remote-ref",
+          model: "agnes-image-2.1-flash",
+          ref: ["https://example.com/ref.png"],
+        },
+      ],
+    }),
+  );
+
+  const mod = await import("./main.ts");
+  assert.equal(typeof (mod as Record<string, unknown>).prepareBatchTasks, "function");
+
+  const prepareBatchTasks = (mod as {
+    prepareBatchTasks: (
+      args: CliArgs,
+      extend: Partial<ExtendConfig>,
+    ) => Promise<{ tasks: Array<{ provider: string }>; jobs: number | null }>;
+  }).prepareBatchTasks;
+
+  const prepared = await prepareBatchTasks(
+    makeArgs({
+      batchFile,
+    }),
+    {},
+  );
+
+  assert.equal(prepared.tasks.length, 1);
+  assert.equal(prepared.tasks[0]?.provider, "agnes");
 });
 
 test("path normalization, worker count, and retry classification follow expected rules", () => {

--- a/skills/baoyu-image-gen/scripts/main.test.ts
+++ b/skills/baoyu-image-gen/scripts/main.test.ts
@@ -83,7 +83,7 @@ test("parseArgs parses the main baoyu-image-gen CLI flags", () => {
     "--image",
     "out/hero",
     "--provider",
-    "zai",
+    "agnes",
     "--quality",
     "2k",
     "--imageSize",
@@ -102,7 +102,7 @@ test("parseArgs parses the main baoyu-image-gen CLI flags", () => {
 
   assert.deepEqual(args.promptFiles, ["prompts/system.md", "prompts/content.md"]);
   assert.equal(args.imagePath, "out/hero");
-  assert.equal(args.provider, "zai");
+  assert.equal(args.provider, "agnes");
   assert.equal(args.quality, "2k");
   assert.equal(args.aspectRatioSource, null);
   assert.equal(args.imageSize, "4K");
@@ -144,6 +144,7 @@ default_image_api_dialect: ratio-metadata
 default_model:
   google: gemini-3-pro-image
   openai: gpt-image-2
+  agnes: agnes-image-2.1-flash
   zai: glm-image
   azure: image-prod
   minimax: image-01
@@ -158,6 +159,9 @@ batch:
     zai:
       concurrency: 2
       start_interval_ms: 1000
+    agnes:
+      concurrency: 2
+      start_interval_ms: 1050
     minimax:
       concurrency: 2
       start_interval_ms: 1400
@@ -176,6 +180,7 @@ batch:
   assert.equal(config.default_image_api_dialect, "ratio-metadata");
   assert.equal(config.default_model?.google, "gemini-3-pro-image");
   assert.equal(config.default_model?.openai, "gpt-image-2");
+  assert.equal(config.default_model?.agnes, "agnes-image-2.1-flash");
   assert.equal(config.default_model?.zai, "glm-image");
   assert.equal(config.default_model?.azure, "image-prod");
   assert.equal(config.default_model?.minimax, "image-01");
@@ -190,6 +195,10 @@ batch:
   assert.deepEqual(config.batch?.provider_limits?.zai, {
     concurrency: 2,
     start_interval_ms: 1000,
+  });
+  assert.deepEqual(config.batch?.provider_limits?.agnes, {
+    concurrency: 2,
+    start_interval_ms: 1050,
   });
   assert.deepEqual(config.batch?.provider_limits?.minimax, {
     concurrency: 2,
@@ -402,6 +411,32 @@ test("detectProvider selects Z.AI when credentials are present or the model id m
   assert.equal(detectProvider(makeArgs({ model: "glm-image" })), "zai");
 });
 
+test("detectProvider selects Agnes when credentials are present or the model id matches", (t) => {
+  useEnv(t, {
+    GOOGLE_API_KEY: null,
+    OPENAI_API_KEY: null,
+    AZURE_OPENAI_API_KEY: null,
+    AZURE_OPENAI_BASE_URL: null,
+    OPENROUTER_API_KEY: null,
+    DASHSCOPE_API_KEY: null,
+    AGNES_API_KEY: "agnes-key",
+    ZAI_API_KEY: null,
+    BIGMODEL_API_KEY: null,
+    MINIMAX_API_KEY: null,
+    REPLICATE_API_TOKEN: null,
+    JIMENG_ACCESS_KEY_ID: null,
+    JIMENG_SECRET_ACCESS_KEY: null,
+    ARK_API_KEY: null,
+  });
+
+  assert.equal(detectProvider(makeArgs()), "agnes");
+  assert.equal(detectProvider(makeArgs({ model: "agnes-image-2.1-flash" })), "agnes");
+  assert.equal(
+    detectProvider(makeArgs({ referenceImages: ["ref.png"] })),
+    "agnes",
+  );
+});
+
 test("detectProvider infers Seedream from model id and allows Seedream reference-image workflows", (t) => {
   useEnv(t, {
     GOOGLE_API_KEY: null,
@@ -488,6 +523,7 @@ test("batch worker and provider-rate-limit configuration prefer env over EXTEND 
     BAOYU_IMAGE_GEN_MAX_WORKERS: "12",
     BAOYU_IMAGE_GEN_GOOGLE_CONCURRENCY: "5",
     BAOYU_IMAGE_GEN_GOOGLE_START_INTERVAL_MS: "450",
+    BAOYU_IMAGE_GEN_AGNES_CONCURRENCY: "6",
     BAOYU_IMAGE_GEN_ZAI_CONCURRENCY: "4",
   });
 
@@ -498,6 +534,10 @@ test("batch worker and provider-rate-limit configuration prefer env over EXTEND 
         google: {
           concurrency: 2,
           start_interval_ms: 900,
+        },
+        agnes: {
+          concurrency: 2,
+          start_interval_ms: 1300,
         },
         zai: {
           concurrency: 1,
@@ -515,6 +555,10 @@ test("batch worker and provider-rate-limit configuration prefer env over EXTEND 
   assert.deepEqual(getConfiguredProviderRateLimits(extendConfig).google, {
     concurrency: 5,
     startIntervalMs: 450,
+  });
+  assert.deepEqual(getConfiguredProviderRateLimits(extendConfig).agnes, {
+    concurrency: 6,
+    startIntervalMs: 1300,
   });
   assert.deepEqual(getConfiguredProviderRateLimits(extendConfig).zai, {
     concurrency: 4,

--- a/skills/baoyu-image-gen/scripts/main.ts
+++ b/skills/baoyu-image-gen/scripts/main.ts
@@ -87,6 +87,8 @@ Options:
   --quality normal|2k       Quality preset (default: 2k)
   --imageSize 1K|2K|4K      Image size for Google/OpenRouter (default: from quality)
   --imageApiDialect <id>    OpenAI-compatible image dialect: openai-native|ratio-metadata
+  --response-format <file|url>
+                           Agnes output mode (default: file)
   --ref <files...>          Reference images (Google, OpenAI, Agnes, Azure, OpenRouter, Replicate supported families, MiniMax, Seedream 4.0/4.5/5.0, or DashScope wan2.7-image*)
   --n <count>               Number of images for the current task (default: 1; Replicate currently requires 1)
   --json                    JSON output
@@ -184,6 +186,7 @@ export function parseArgs(argv: string[]): CliArgs {
     imageSize: null,
     imageSizeSource: null,
     imageApiDialect: null,
+    responseFormat: null,
     referenceImages: [],
     n: 1,
     batchFile: null,
@@ -321,6 +324,15 @@ export function parseArgs(argv: string[]): CliArgs {
         throw new Error(`Invalid imageApiDialect: ${v}`);
       }
       out.imageApiDialect = v;
+      continue;
+    }
+
+    if (a === "--response-format") {
+      const v = argv[++i];
+      if (v !== "file" && v !== "url") {
+        throw new Error(`Invalid responseFormat: ${v}`);
+      }
+      out.responseFormat = v;
       continue;
     }
 
@@ -911,19 +923,19 @@ function getModelForProvider(
   return providerModule.getDefaultModel();
 }
 
-async function prepareSingleTask(args: CliArgs, extendConfig: Partial<ExtendConfig>): Promise<PreparedTask> {
+export async function prepareSingleTask(args: CliArgs, extendConfig: Partial<ExtendConfig>): Promise<PreparedTask> {
   if (!args.quality) args.quality = "2k";
 
   const prompt = (await loadPromptForArgs(args)) ?? (await readPromptFromStdin());
   if (!prompt) throw new Error("Prompt is required");
   if (!args.imagePath) throw new Error("--image is required");
+  const provider = detectProvider(args);
   if (args.referenceImages.length > 0) {
     await validateReferenceImages(args.referenceImages, {
-      allowRemoteUrls: shouldAllowRemoteReferenceImages(args.provider),
+      allowRemoteUrls: shouldAllowRemoteReferenceImages(provider),
     });
   }
 
-  const provider = detectProvider(args);
   const providerModule = await loadProviderModule(provider);
   const model = getModelForProvider(provider, args.model, extendConfig, providerModule);
   providerModule.validateArgs?.(model, args);
@@ -989,6 +1001,7 @@ export function createTaskArgs(baseArgs: CliArgs, task: BatchTaskInput, batchDir
     imageSize: task.imageSize ?? baseArgs.imageSize ?? null,
     imageSizeSource: task.imageSize != null ? "task" : (baseArgs.imageSizeSource ?? null),
     imageApiDialect: task.imageApiDialect ?? baseArgs.imageApiDialect ?? null,
+    responseFormat: task.responseFormat ?? baseArgs.responseFormat ?? null,
     referenceImages: task.ref ? task.ref.map((filePath) => resolveBatchReferencePath(batchDir, filePath)) : [],
     n: task.n ?? baseArgs.n,
     batchFile: null,
@@ -998,7 +1011,7 @@ export function createTaskArgs(baseArgs: CliArgs, task: BatchTaskInput, batchDir
   };
 }
 
-async function prepareBatchTasks(
+export async function prepareBatchTasks(
   args: CliArgs,
   extendConfig: Partial<ExtendConfig>
 ): Promise<{ tasks: PreparedTask[]; jobs: number | null }> {
@@ -1013,13 +1026,13 @@ async function prepareBatchTasks(
     const prompt = await loadPromptForArgs(taskArgs);
     if (!prompt) throw new Error(`Task ${i + 1} is missing prompt or promptFiles.`);
     if (!taskArgs.imagePath) throw new Error(`Task ${i + 1} is missing image output path.`);
+    const provider = detectProvider(taskArgs);
     if (taskArgs.referenceImages.length > 0) {
       await validateReferenceImages(taskArgs.referenceImages, {
-        allowRemoteUrls: shouldAllowRemoteReferenceImages(taskArgs.provider),
+        allowRemoteUrls: shouldAllowRemoteReferenceImages(provider),
       });
     }
 
-    const provider = detectProvider(taskArgs);
     const providerModule = await loadProviderModule(provider);
     const model = getModelForProvider(provider, taskArgs.model, extendConfig, providerModule);
     providerModule.validateArgs?.(model, taskArgs);

--- a/skills/baoyu-image-gen/scripts/main.ts
+++ b/skills/baoyu-image-gen/scripts/main.ts
@@ -57,6 +57,7 @@ const DEFAULT_PROVIDER_RATE_LIMITS: Record<Provider, ProviderRateLimit> = {
   replicate: { concurrency: 5, startIntervalMs: 700 },
   google: { concurrency: 3, startIntervalMs: 1100 },
   openai: { concurrency: 3, startIntervalMs: 1100 },
+  agnes: { concurrency: 3, startIntervalMs: 1100 },
   openrouter: { concurrency: 3, startIntervalMs: 1100 },
   dashscope: { concurrency: 3, startIntervalMs: 1100 },
   zai: { concurrency: 3, startIntervalMs: 1100 },
@@ -79,14 +80,14 @@ Options:
   --image <path>            Output image path (required in single-image mode)
   --batchfile <path>        JSON batch file for multi-image generation
   --jobs <count>            Worker count for batch mode (default: auto, max from config, built-in default 10)
-  --provider google|openai|openrouter|dashscope|zai|minimax|replicate|jimeng|seedream|azure|codex-cli  Force provider (auto-detect by default)
+  --provider google|openai|agnes|openrouter|dashscope|zai|minimax|replicate|jimeng|seedream|azure|codex-cli  Force provider (auto-detect by default)
   -m, --model <id>          Model ID
   --ar <ratio>              Aspect ratio (e.g., 16:9, 1:1, 4:3)
   --size <WxH>              Size (e.g., 1024x1024)
   --quality normal|2k       Quality preset (default: 2k)
   --imageSize 1K|2K|4K      Image size for Google/OpenRouter (default: from quality)
   --imageApiDialect <id>    OpenAI-compatible image dialect: openai-native|ratio-metadata
-  --ref <files...>          Reference images (Google, OpenAI, Azure, OpenRouter, Replicate supported families, MiniMax, Seedream 4.0/4.5/5.0, or DashScope wan2.7-image*)
+  --ref <files...>          Reference images (Google, OpenAI, Agnes, Azure, OpenRouter, Replicate supported families, MiniMax, Seedream 4.0/4.5/5.0, or DashScope wan2.7-image*)
   --n <count>               Number of images for the current task (default: 1; Replicate currently requires 1)
   --json                    JSON output
   -h, --help                Show help
@@ -112,8 +113,9 @@ Behavior:
   - Batch summary reports success count, failure count, and per-image errors
   - Replicate currently supports single-image save semantics only; --n must stay at 1
 
-Environment variables:
+  Environment variables:
   OPENAI_API_KEY            OpenAI API key
+  AGNES_API_KEY             Agnes API key
   OPENROUTER_API_KEY        OpenRouter API key
   GOOGLE_API_KEY            Google API key
   GEMINI_API_KEY            Gemini API key (alias for GOOGLE_API_KEY)
@@ -126,6 +128,7 @@ Environment variables:
   JIMENG_SECRET_ACCESS_KEY  Jimeng Secret Access Key
   ARK_API_KEY               Seedream/Ark API key
   OPENAI_IMAGE_MODEL        Default OpenAI model (gpt-image-2)
+  AGNES_IMAGE_MODEL         Default Agnes model (agnes-image-2.1-flash)
   OPENROUTER_IMAGE_MODEL    Default OpenRouter model (google/gemini-3.1-flash-image)
   GOOGLE_IMAGE_MODEL        Default Google model (gemini-3-pro-image)
   DASHSCOPE_IMAGE_MODEL     Default DashScope model (qwen-image-2.0-pro)
@@ -136,6 +139,7 @@ Environment variables:
   JIMENG_IMAGE_MODEL        Default Jimeng model (jimeng_t2i_v40)
   SEEDREAM_IMAGE_MODEL      Default Seedream model (doubao-seedream-5-0-260128)
   OPENAI_BASE_URL           Custom OpenAI endpoint
+  AGNES_BASE_URL            Custom Agnes endpoint
   OPENAI_IMAGE_API_DIALECT  OpenAI-compatible image dialect (openai-native|ratio-metadata)
   OPENAI_IMAGE_USE_CHAT     Use /chat/completions instead of /images/generations (true|false)
   OPENROUTER_BASE_URL       Custom OpenRouter endpoint
@@ -257,6 +261,7 @@ export function parseArgs(argv: string[]): CliArgs {
       if (
         v !== "google" &&
         v !== "openai" &&
+        v !== "agnes" &&
         v !== "openrouter" &&
         v !== "dashscope" &&
         v !== "zai" &&
@@ -429,6 +434,7 @@ export function parseSimpleYaml(yaml: string): Partial<ExtendConfig> {
         config.default_model = {
           google: null,
           openai: null,
+          agnes: null,
           openrouter: null,
           dashscope: null,
           zai: null,
@@ -459,6 +465,7 @@ export function parseSimpleYaml(yaml: string): Partial<ExtendConfig> {
         (
           key === "google" ||
           key === "openai" ||
+          key === "agnes" ||
           key === "openrouter" ||
           key === "dashscope" ||
           key === "zai" ||
@@ -479,6 +486,7 @@ export function parseSimpleYaml(yaml: string): Partial<ExtendConfig> {
         (
           key === "google" ||
           key === "openai" ||
+          key === "agnes" ||
           key === "openrouter" ||
           key === "dashscope" ||
           key === "zai" ||
@@ -633,6 +641,7 @@ export function getConfiguredProviderRateLimits(
     replicate: { ...DEFAULT_PROVIDER_RATE_LIMITS.replicate },
     google: { ...DEFAULT_PROVIDER_RATE_LIMITS.google },
     openai: { ...DEFAULT_PROVIDER_RATE_LIMITS.openai },
+    agnes: { ...DEFAULT_PROVIDER_RATE_LIMITS.agnes },
     openrouter: { ...DEFAULT_PROVIDER_RATE_LIMITS.openrouter },
     dashscope: { ...DEFAULT_PROVIDER_RATE_LIMITS.dashscope },
     zai: { ...DEFAULT_PROVIDER_RATE_LIMITS.zai },
@@ -643,7 +652,7 @@ export function getConfiguredProviderRateLimits(
     "codex-cli": { ...DEFAULT_PROVIDER_RATE_LIMITS["codex-cli"] },
   };
 
-  for (const provider of ["replicate", "google", "openai", "openrouter", "dashscope", "zai", "minimax", "jimeng", "seedream", "azure", "codex-cli"] as Provider[]) {
+  for (const provider of ["replicate", "google", "openai", "agnes", "openrouter", "dashscope", "zai", "minimax", "jimeng", "seedream", "azure", "codex-cli"] as Provider[]) {
     const envPrefix = `BAOYU_IMAGE_GEN_${provider.toUpperCase().replace(/-/g, "_")}`;
     const extendLimit = extendConfig.batch?.provider_limits?.[provider];
     configured[provider] = {
@@ -692,7 +701,8 @@ export function normalizeOutputImagePath(p: string, defaultExtension = ".png"): 
 
 function inferProviderFromModel(model: string | null): Provider | null {
   if (!model) return null;
-  const normalized = model.trim();
+  const normalized = model.trim().toLowerCase();
+  if (normalized.includes("agnes-image")) return "agnes";
   if (normalized.includes("seedream") || normalized.includes("seededit")) return "seedream";
   if (normalized === "image-01" || normalized === "image-01-live") return "minimax";
   if (normalized === "glm-image" || normalized === "cogview-4-250304") return "zai";
@@ -705,6 +715,7 @@ export function detectProvider(args: CliArgs): Provider {
     args.provider &&
     args.provider !== "google" &&
     args.provider !== "openai" &&
+    args.provider !== "agnes" &&
     args.provider !== "azure" &&
     args.provider !== "openrouter" &&
     args.provider !== "replicate" &&
@@ -714,7 +725,7 @@ export function detectProvider(args: CliArgs): Provider {
     args.provider !== "codex-cli"
   ) {
     throw new Error(
-      "Reference images require a ref-capable provider. Use --provider google (Gemini multimodal), --provider openai (GPT Image edits), --provider azure (Azure OpenAI), --provider openrouter (OpenRouter multimodal), --provider replicate, --provider dashscope with a wan2.7 image model, --provider seedream for supported Seedream models, --provider minimax for MiniMax subject-reference workflows, or --provider codex-cli (Codex image_gen with references)."
+      "Reference images require a ref-capable provider. Use --provider google (Gemini multimodal), --provider openai (GPT Image edits), --provider agnes (Agnes Image 2.1 Flash), --provider azure (Azure OpenAI), --provider openrouter (OpenRouter multimodal), --provider replicate, --provider dashscope with a wan2.7 image model, --provider seedream for supported Seedream models, --provider minimax for MiniMax subject-reference workflows, or --provider codex-cli (Codex image_gen with references)."
     );
   }
 
@@ -723,6 +734,7 @@ export function detectProvider(args: CliArgs): Provider {
   const hasGoogle = !!(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
   const hasAzure = !!(process.env.AZURE_OPENAI_API_KEY && process.env.AZURE_OPENAI_BASE_URL);
   const hasOpenai = !!process.env.OPENAI_API_KEY;
+  const hasAgnes = !!process.env.AGNES_API_KEY;
   const hasOpenrouter = !!process.env.OPENROUTER_API_KEY;
   const hasDashscope = !!process.env.DASHSCOPE_API_KEY;
   const hasZai = !!(process.env.ZAI_API_KEY || process.env.BIGMODEL_API_KEY);
@@ -753,22 +765,31 @@ export function detectProvider(args: CliArgs): Provider {
     return "zai";
   }
 
+  if (modelProvider === "agnes") {
+    if (!hasAgnes) {
+      throw new Error("Model looks like an Agnes image model, but AGNES_API_KEY is not set.");
+    }
+    return "agnes";
+  }
+
   if (args.referenceImages.length > 0) {
     if (hasGoogle) return "google";
     if (hasOpenai) return "openai";
+    if (hasAgnes) return "agnes";
     if (hasAzure) return "azure";
     if (hasOpenrouter) return "openrouter";
     if (hasReplicate) return "replicate";
     if (hasSeedream) return "seedream";
     if (hasMinimax) return "minimax";
     throw new Error(
-      "Reference images require Google, OpenAI, Azure, OpenRouter, Replicate, supported Seedream models, or MiniMax. Set GOOGLE_API_KEY/GEMINI_API_KEY, OPENAI_API_KEY, AZURE_OPENAI_API_KEY+AZURE_OPENAI_BASE_URL, OPENROUTER_API_KEY, REPLICATE_API_TOKEN, ARK_API_KEY, or MINIMAX_API_KEY, or remove --ref."
+      "Reference images require Google, OpenAI, Agnes, Azure, OpenRouter, Replicate, supported Seedream models, or MiniMax. Set GOOGLE_API_KEY/GEMINI_API_KEY, OPENAI_API_KEY, AGNES_API_KEY, AZURE_OPENAI_API_KEY+AZURE_OPENAI_BASE_URL, OPENROUTER_API_KEY, REPLICATE_API_TOKEN, ARK_API_KEY, or MINIMAX_API_KEY, or remove --ref."
     );
   }
 
   const available = [
     hasGoogle && "google",
     hasOpenai && "openai",
+    hasAgnes && "agnes",
     hasAzure && "azure",
     hasOpenrouter && "openrouter",
     hasDashscope && "dashscope",
@@ -783,7 +804,7 @@ export function detectProvider(args: CliArgs): Provider {
   if (available.length > 1) return available[0]!;
 
   throw new Error(
-    "No API key found. Set GOOGLE_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, AZURE_OPENAI_API_KEY+AZURE_OPENAI_BASE_URL, OPENROUTER_API_KEY, DASHSCOPE_API_KEY, ZAI_API_KEY, MINIMAX_API_KEY, REPLICATE_API_TOKEN, JIMENG keys, or ARK_API_KEY.\n" +
+    "No API key found. Set GOOGLE_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, AGNES_API_KEY, AZURE_OPENAI_API_KEY+AZURE_OPENAI_BASE_URL, OPENROUTER_API_KEY, DASHSCOPE_API_KEY, ZAI_API_KEY, MINIMAX_API_KEY, REPLICATE_API_TOKEN, JIMENG keys, or ARK_API_KEY.\n" +
       "Create ~/.baoyu-skills/.env or <cwd>/.baoyu-skills/.env with your keys."
   );
 }
@@ -797,7 +818,7 @@ function isRemoteReferenceImage(refPath: string): boolean {
 }
 
 function shouldAllowRemoteReferenceImages(provider: Provider | null): boolean {
-  return provider === "dashscope";
+  return provider === "dashscope" || provider === "agnes";
 }
 
 export async function validateReferenceImages(
@@ -843,6 +864,7 @@ export function isRetryableGenerationError(error: unknown): boolean {
 
 async function loadProviderModule(provider: Provider): Promise<ProviderModule> {
   if (provider === "google") return (await import("./providers/google")) as ProviderModule;
+  if (provider === "agnes") return (await import("./providers/agnes")) as ProviderModule;
   if (provider === "dashscope") return (await import("./providers/dashscope")) as ProviderModule;
   if (provider === "zai") return (await import("./providers/zai")) as ProviderModule;
   if (provider === "minimax") return (await import("./providers/minimax")) as ProviderModule;
@@ -873,6 +895,7 @@ function getModelForProvider(
   if (extendConfig.default_model) {
     if (provider === "google" && extendConfig.default_model.google) return extendConfig.default_model.google;
     if (provider === "openai" && extendConfig.default_model.openai) return extendConfig.default_model.openai;
+    if (provider === "agnes" && extendConfig.default_model.agnes) return extendConfig.default_model.agnes;
     if (provider === "openrouter" && extendConfig.default_model.openrouter) {
       return extendConfig.default_model.openrouter;
     }
@@ -1118,7 +1141,7 @@ async function runBatchTasks(
   const acquireProvider = createProviderGate(providerRateLimits);
   const workerCount = getWorkerCount(tasks.length, jobs, maxWorkers);
   console.error(`Batch mode: ${tasks.length} tasks, ${workerCount} workers, parallel mode enabled.`);
-  for (const provider of ["replicate", "google", "openai", "openrouter", "dashscope", "zai", "minimax", "jimeng", "seedream", "azure", "codex-cli"] as Provider[]) {
+  for (const provider of ["replicate", "google", "openai", "agnes", "openrouter", "dashscope", "zai", "minimax", "jimeng", "seedream", "azure", "codex-cli"] as Provider[]) {
     const limit = providerRateLimits[provider];
     console.error(`- ${provider}: concurrency=${limit.concurrency}, startIntervalMs=${limit.startIntervalMs}`);
   }

--- a/skills/baoyu-image-gen/scripts/providers/agnes.test.ts
+++ b/skills/baoyu-image-gen/scripts/providers/agnes.test.ts
@@ -7,7 +7,9 @@ import test, { type TestContext } from "node:test";
 import type { CliArgs } from "../types.ts";
 import {
   buildAgnesUrl,
+  generateImage,
   extractImageFromResponse,
+  getDefaultOutputExtension,
   getDefaultModel,
   parseAspectRatio,
   parseSize,
@@ -29,6 +31,7 @@ function makeArgs(overrides: Partial<CliArgs> = {}): CliArgs {
     quality: "2k",
     imageSize: null,
     imageApiDialect: null,
+    responseFormat: null,
     referenceImages: [],
     n: 1,
     batchFile: null,
@@ -148,6 +151,53 @@ test("Agnes request bodies use return_base64 for text-to-image and extra_body im
   assert.match(editBody.extra_body?.image?.[0] ?? "", /^data:image\/png;base64,/);
 });
 
+test("Agnes URL output switches extension and request format", async (t) => {
+  const root = await makeTempDir("agnes-provider-url-");
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+
+  const refPath = path.join(root, "ref.png");
+  await fs.writeFile(
+    refPath,
+    Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aX8kAAAAASUVORK5CYII=", "base64"),
+  );
+
+  assert.equal(
+    getDefaultOutputExtension("agnes-image-2.1-flash", makeArgs({ responseFormat: "url" })),
+    ".txt",
+  );
+  assert.equal(
+    getDefaultOutputExtension("agnes-image-2.1-flash", makeArgs()),
+    ".png",
+  );
+
+  assert.deepEqual(
+    buildTextToImageBody("Draw a skyline", "agnes-image-2.1-flash", makeArgs({
+      aspectRatio: "16:9",
+      quality: "normal",
+      responseFormat: "url",
+    })),
+    {
+      model: "agnes-image-2.1-flash",
+      prompt: "Draw a skyline",
+      size: "1360x768",
+      extra_body: {
+        response_format: "url",
+      },
+    },
+  );
+
+  const editBody = await buildImageToImageBody(
+    "Make the square red",
+    "agnes-image-2.1-flash",
+    makeArgs({
+      referenceImages: [refPath],
+      size: "1024x1024",
+      responseFormat: "url",
+    }),
+  );
+  assert.deepEqual(editBody.extra_body?.response_format, "url");
+});
+
 test("Agnes response extraction supports base64 and URL download flows", async (t) => {
   const originalFetch = globalThis.fetch;
   t.after(() => {
@@ -173,5 +223,45 @@ test("Agnes response extraction supports base64 and URL download flows", async (
   await assert.rejects(
     () => extractImageFromResponse({ data: [{}] }),
     /No image in response/,
+  );
+});
+
+test("Agnes URL output returns URL text and API errors include HTTP status", async (t) => {
+  useEnv(t, {
+    AGNES_API_KEY: "agnes-key",
+  });
+
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        data: [{ url: "https://cdn.example.com/agnes.png" }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+
+  const urlBytes = await generateImage(
+    "Draw a skyline",
+    "agnes-image-2.1-flash",
+    makeArgs({ responseFormat: "url" }),
+  );
+  assert.equal(Buffer.from(urlBytes).toString("utf8"), "https://cdn.example.com/agnes.png");
+
+  globalThis.fetch = async () =>
+    new Response("denied", {
+      status: 401,
+      headers: { "Content-Type": "text/plain" },
+    });
+
+  await assert.rejects(
+    () => generateImage("Draw a skyline", "agnes-image-2.1-flash", makeArgs()),
+    /Agnes API error \(401\): denied/,
   );
 });

--- a/skills/baoyu-image-gen/scripts/providers/agnes.test.ts
+++ b/skills/baoyu-image-gen/scripts/providers/agnes.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+
+import type { CliArgs } from "../types.ts";
+import {
+  buildAgnesUrl,
+  extractImageFromResponse,
+  getDefaultModel,
+  parseAspectRatio,
+  parseSize,
+  resolveSize,
+  validateArgs,
+  buildTextToImageBody,
+  buildImageToImageBody,
+} from "./agnes.ts";
+
+function makeArgs(overrides: Partial<CliArgs> = {}): CliArgs {
+  return {
+    prompt: null,
+    promptFiles: [],
+    imagePath: null,
+    provider: null,
+    model: null,
+    aspectRatio: null,
+    size: null,
+    quality: "2k",
+    imageSize: null,
+    imageApiDialect: null,
+    referenceImages: [],
+    n: 1,
+    batchFile: null,
+    jobs: null,
+    json: false,
+    help: false,
+    ...overrides,
+  };
+}
+
+function useEnv(
+  t: TestContext,
+  values: Record<string, string | null>,
+): void {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, process.env[key]);
+    if (value == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  t.after(() => {
+    for (const [key, value] of previous.entries()) {
+      if (value == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+}
+
+async function makeTempDir(prefix: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+test("Agnes default model and endpoint honor env overrides", (t) => {
+  useEnv(t, {
+    AGNES_IMAGE_MODEL: null,
+    AGNES_BASE_URL: null,
+  });
+
+  assert.equal(getDefaultModel(), "agnes-image-2.1-flash");
+  assert.equal(buildAgnesUrl(), "https://apihub.agnes-ai.com/v1/images/generations");
+
+  process.env.AGNES_IMAGE_MODEL = "agnes-image-2.1-pro";
+  process.env.AGNES_BASE_URL = "https://proxy.example.com/v1/";
+  assert.equal(getDefaultModel(), "agnes-image-2.1-pro");
+  assert.equal(buildAgnesUrl(), "https://proxy.example.com/v1/images/generations");
+});
+
+test("Agnes size helpers resolve custom and aspect-ratio-driven sizes", () => {
+  assert.deepEqual(parseAspectRatio("16:9"), { width: 16, height: 9 });
+  assert.equal(parseAspectRatio("wide"), null);
+  assert.deepEqual(parseSize("1024x768"), { width: 1024, height: 768 });
+  assert.equal(parseSize("big"), null);
+
+  assert.equal(
+    resolveSize(makeArgs({ aspectRatio: "16:9", quality: "2k" })),
+    "2048x1152",
+  );
+  assert.equal(
+    resolveSize(makeArgs({ aspectRatio: "4:3", quality: "normal" })),
+    "1184x896",
+  );
+  assert.equal(
+    resolveSize(makeArgs({ size: "1024x768" })),
+    "1024x768",
+  );
+});
+
+test("Agnes validates unsupported multi-image requests and explicit sizes", () => {
+  assert.throws(
+    () => validateArgs("agnes-image-2.1-flash", makeArgs({ n: 2 })),
+    /single image per request/,
+  );
+  assert.throws(
+    () => validateArgs("agnes-image-2.1-flash", makeArgs({ size: "1024" })),
+    /WxH format/,
+  );
+});
+
+test("Agnes request bodies use return_base64 for text-to-image and extra_body image for edits", async (t) => {
+  const root = await makeTempDir("agnes-provider-");
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+
+  const refPath = path.join(root, "ref.png");
+  await fs.writeFile(
+    refPath,
+    Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aX8kAAAAASUVORK5CYII=", "base64"),
+  );
+
+  assert.deepEqual(
+    buildTextToImageBody("Draw a skyline", "agnes-image-2.1-flash", makeArgs({ aspectRatio: "16:9", quality: "normal" })),
+    {
+      model: "agnes-image-2.1-flash",
+      prompt: "Draw a skyline",
+      size: "1360x768",
+      return_base64: true,
+    },
+  );
+
+  const editBody = await buildImageToImageBody(
+    "Make the square red",
+    "agnes-image-2.1-flash",
+    makeArgs({ referenceImages: [refPath], size: "1024x1024" }),
+  );
+
+  assert.equal(editBody.model, "agnes-image-2.1-flash");
+  assert.equal(editBody.prompt, "Make the square red");
+  assert.equal(editBody.size, "1024x1024");
+  assert.deepEqual(editBody.extra_body?.response_format, "b64_json");
+  assert.equal(Array.isArray(editBody.extra_body?.image), true);
+  assert.match(editBody.extra_body?.image?.[0] ?? "", /^data:image\/png;base64,/);
+});
+
+test("Agnes response extraction supports base64 and URL download flows", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const fromBase64 = await extractImageFromResponse({
+    data: [{ b64_json: Buffer.from("hello").toString("base64") }],
+  });
+  assert.equal(Buffer.from(fromBase64).toString("utf8"), "hello");
+
+  globalThis.fetch = async () =>
+    new Response(Uint8Array.from([1, 2, 3]), {
+      status: 200,
+      headers: { "Content-Type": "image/png" },
+    });
+
+  const fromUrl = await extractImageFromResponse({
+    data: [{ url: "https://cdn.example.com/agnes.png" }],
+  });
+  assert.deepEqual([...fromUrl], [1, 2, 3]);
+
+  await assert.rejects(
+    () => extractImageFromResponse({ data: [{}] }),
+    /No image in response/,
+  );
+});

--- a/skills/baoyu-image-gen/scripts/providers/agnes.ts
+++ b/skills/baoyu-image-gen/scripts/providers/agnes.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { readFile } from "node:fs/promises";
-import type { CliArgs, Quality } from "../types";
+import type { CliArgs, Quality, ResponseFormat } from "../types";
 
 type AgnesResponse = {
   data?: Array<{ url?: string | null; b64_json?: string | null }>;
@@ -10,7 +10,10 @@ type AgnesTextToImageBody = {
   model: string;
   prompt: string;
   size: string;
-  return_base64: true;
+  return_base64?: true;
+  extra_body?: {
+    response_format: "url";
+  };
 };
 
 type AgnesImageToImageBody = {
@@ -19,7 +22,7 @@ type AgnesImageToImageBody = {
   size: string;
   extra_body: {
     image: string[];
-    response_format: "b64_json";
+    response_format: "b64_json" | "url";
   };
 };
 
@@ -89,6 +92,10 @@ function normalizeQuality(quality: CliArgs["quality"]): Quality {
   return quality === "normal" ? "normal" : "2k";
 }
 
+function resolveResponseFormat(responseFormat: ResponseFormat | null): "b64_json" | "url" {
+  return responseFormat === "url" ? "url" : "b64_json";
+}
+
 export function resolveSize(args: Pick<CliArgs, "size" | "aspectRatio" | "quality">): string {
   if (args.size) {
     const parsed = parseSize(args.size);
@@ -144,11 +151,26 @@ export function validateArgs(_model: string, args: CliArgs): void {
   }
 }
 
+export function getDefaultOutputExtension(_model: string, args: CliArgs): ".png" | ".txt" {
+  return args.responseFormat === "url" ? ".txt" : ".png";
+}
+
 export function buildTextToImageBody(
   prompt: string,
   model: string,
-  args: Pick<CliArgs, "size" | "aspectRatio" | "quality">,
+  args: Pick<CliArgs, "size" | "aspectRatio" | "quality" | "responseFormat">,
 ): AgnesTextToImageBody {
+  if (args.responseFormat === "url") {
+    return {
+      model,
+      prompt,
+      size: resolveSize(args),
+      extra_body: {
+        response_format: "url",
+      },
+    };
+  }
+
   return {
     model,
     prompt,
@@ -160,7 +182,7 @@ export function buildTextToImageBody(
 export async function buildImageToImageBody(
   prompt: string,
   model: string,
-  args: Pick<CliArgs, "size" | "aspectRatio" | "quality" | "referenceImages">,
+  args: Pick<CliArgs, "size" | "aspectRatio" | "quality" | "referenceImages" | "responseFormat">,
 ): Promise<AgnesImageToImageBody> {
   const images = await Promise.all(args.referenceImages.map((refPath) => loadReferenceImage(refPath)));
   return {
@@ -169,7 +191,7 @@ export async function buildImageToImageBody(
     size: resolveSize(args),
     extra_body: {
       image: images,
-      response_format: "b64_json",
+      response_format: resolveResponseFormat(args.responseFormat),
     },
   };
 }
@@ -183,7 +205,7 @@ export async function extractImageFromResponse(result: AgnesResponse): Promise<U
   if (image?.url) {
     const response = await fetch(image.url);
     if (!response.ok) {
-      throw new Error("Failed to download Agnes image");
+      throw new Error(`Failed to download Agnes image: ${response.status}`);
     }
     return new Uint8Array(await response.arrayBuffer());
   }
@@ -213,8 +235,17 @@ export async function generateImage(
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Agnes API error: ${errorText}`);
+    throw new Error(`Agnes API error (${response.status}): ${errorText}`);
   }
 
-  return extractImageFromResponse((await response.json()) as AgnesResponse);
+  const result = (await response.json()) as AgnesResponse;
+  if (args.responseFormat === "url") {
+    const url = result.data?.[0]?.url;
+    if (!url) {
+      throw new Error("No URL in response");
+    }
+    return new Uint8Array(Buffer.from(url, "utf8"));
+  }
+
+  return extractImageFromResponse(result);
 }

--- a/skills/baoyu-image-gen/scripts/providers/agnes.ts
+++ b/skills/baoyu-image-gen/scripts/providers/agnes.ts
@@ -1,0 +1,220 @@
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import type { CliArgs, Quality } from "../types";
+
+type AgnesResponse = {
+  data?: Array<{ url?: string | null; b64_json?: string | null }>;
+};
+
+type AgnesTextToImageBody = {
+  model: string;
+  prompt: string;
+  size: string;
+  return_base64: true;
+};
+
+type AgnesImageToImageBody = {
+  model: string;
+  prompt: string;
+  size: string;
+  extra_body: {
+    image: string[];
+    response_format: "b64_json";
+  };
+};
+
+const DEFAULT_MODEL = "agnes-image-2.1-flash";
+const DEFAULT_BASE_URL = "https://apihub.agnes-ai.com/v1";
+const SIZE_STEP = 16;
+
+const TARGET_PIXELS: Record<Quality, number> = {
+  normal: 1024 * 1024,
+  "2k": 1536 * 1536,
+};
+
+export function getDefaultModel(): string {
+  return process.env.AGNES_IMAGE_MODEL || DEFAULT_MODEL;
+}
+
+function getApiKey(): string {
+  const key = process.env.AGNES_API_KEY;
+  if (!key) {
+    throw new Error("AGNES_API_KEY is required. Get it from https://agnes-ai.com/");
+  }
+  return key;
+}
+
+export function buildAgnesUrl(): string {
+  const base = (process.env.AGNES_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/g, "");
+  if (base.endsWith("/images/generations")) return base;
+  if (base.endsWith("/v1")) return `${base}/images/generations`;
+  return `${base}/v1/images/generations`;
+}
+
+export function parseAspectRatio(ar: string): { width: number; height: number } | null {
+  const match = ar.match(/^(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)$/);
+  if (!match) return null;
+
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+
+  return { width, height };
+}
+
+export function parseSize(size: string): { width: number; height: number } | null {
+  const match = size.trim().match(/^(\d+)\s*[xX]\s*(\d+)$/);
+  if (!match) return null;
+
+  const width = parseInt(match[1]!, 10);
+  const height = parseInt(match[2]!, 10);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+
+  return { width, height };
+}
+
+function roundToStep(value: number): number {
+  return Math.max(SIZE_STEP, Math.round(value / SIZE_STEP) * SIZE_STEP);
+}
+
+function formatSize(width: number, height: number): string {
+  return `${width}x${height}`;
+}
+
+function normalizeQuality(quality: CliArgs["quality"]): Quality {
+  return quality === "normal" ? "normal" : "2k";
+}
+
+export function resolveSize(args: Pick<CliArgs, "size" | "aspectRatio" | "quality">): string {
+  if (args.size) {
+    const parsed = parseSize(args.size);
+    if (!parsed) {
+      throw new Error("Agnes --size must be in WxH format, for example 1024x768.");
+    }
+    return formatSize(parsed.width, parsed.height);
+  }
+
+  const quality = normalizeQuality(args.quality);
+  if (!args.aspectRatio) {
+    const edge = quality === "normal" ? 1024 : 1536;
+    return formatSize(edge, edge);
+  }
+
+  const parsedRatio = parseAspectRatio(args.aspectRatio);
+  if (!parsedRatio) {
+    throw new Error(`Invalid Agnes aspect ratio: ${args.aspectRatio}`);
+  }
+
+  const ratio = parsedRatio.width / parsedRatio.height;
+  const targetPixels = TARGET_PIXELS[quality];
+  const width = roundToStep(Math.sqrt(targetPixels * ratio));
+  const height = roundToStep(width / ratio);
+  return formatSize(width, height);
+}
+
+function getReferenceMime(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  if (ext === ".webp") return "image/webp";
+  if (ext === ".gif") return "image/gif";
+  return "image/png";
+}
+
+async function loadReferenceImage(refPath: string): Promise<string> {
+  if (/^https?:\/\//i.test(refPath)) {
+    return refPath;
+  }
+
+  const fullPath = path.resolve(refPath);
+  const bytes = await readFile(fullPath);
+  return `data:${getReferenceMime(fullPath)};base64,${bytes.toString("base64")}`;
+}
+
+export function validateArgs(_model: string, args: CliArgs): void {
+  if (args.n > 1) {
+    throw new Error("Agnes image generation currently supports only a single image per request in baoyu-image-gen.");
+  }
+
+  if (args.size && !parseSize(args.size)) {
+    throw new Error("Agnes --size must be in WxH format, for example 1024x768.");
+  }
+}
+
+export function buildTextToImageBody(
+  prompt: string,
+  model: string,
+  args: Pick<CliArgs, "size" | "aspectRatio" | "quality">,
+): AgnesTextToImageBody {
+  return {
+    model,
+    prompt,
+    size: resolveSize(args),
+    return_base64: true,
+  };
+}
+
+export async function buildImageToImageBody(
+  prompt: string,
+  model: string,
+  args: Pick<CliArgs, "size" | "aspectRatio" | "quality" | "referenceImages">,
+): Promise<AgnesImageToImageBody> {
+  const images = await Promise.all(args.referenceImages.map((refPath) => loadReferenceImage(refPath)));
+  return {
+    model,
+    prompt,
+    size: resolveSize(args),
+    extra_body: {
+      image: images,
+      response_format: "b64_json",
+    },
+  };
+}
+
+export async function extractImageFromResponse(result: AgnesResponse): Promise<Uint8Array> {
+  const image = result.data?.[0];
+  if (image?.b64_json) {
+    return Uint8Array.from(Buffer.from(image.b64_json, "base64"));
+  }
+
+  if (image?.url) {
+    const response = await fetch(image.url);
+    if (!response.ok) {
+      throw new Error("Failed to download Agnes image");
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
+  throw new Error("No image in response");
+}
+
+export async function generateImage(
+  prompt: string,
+  model: string,
+  args: CliArgs,
+): Promise<Uint8Array> {
+  validateArgs(model, args);
+
+  const body = args.referenceImages.length > 0
+    ? await buildImageToImageBody(prompt, model, args)
+    : buildTextToImageBody(prompt, model, args);
+
+  const response = await fetch(buildAgnesUrl(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${getApiKey()}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Agnes API error: ${errorText}`);
+  }
+
+  return extractImageFromResponse((await response.json()) as AgnesResponse);
+}

--- a/skills/baoyu-image-gen/scripts/types.ts
+++ b/skills/baoyu-image-gen/scripts/types.ts
@@ -13,6 +13,7 @@ export type Provider =
   | "codex-cli";
 export type Quality = "normal" | "2k";
 export type OpenAIImageApiDialect = "openai-native" | "ratio-metadata";
+export type ResponseFormat = "file" | "url";
 
 export type CliArgs = {
   prompt: string | null;
@@ -27,6 +28,7 @@ export type CliArgs = {
   imageSize: string | null;
   imageSizeSource?: "cli" | "task" | "config" | null;
   imageApiDialect: OpenAIImageApiDialect | null;
+  responseFormat: ResponseFormat | null;
   referenceImages: string[];
   n: number;
   batchFile: string | null;
@@ -47,6 +49,7 @@ export type BatchTaskInput = {
   quality?: Quality | null;
   imageSize?: "1K" | "2K" | "4K" | null;
   imageApiDialect?: OpenAIImageApiDialect | null;
+  responseFormat?: ResponseFormat | null;
   ref?: string[];
   n?: number;
 };

--- a/skills/baoyu-image-gen/scripts/types.ts
+++ b/skills/baoyu-image-gen/scripts/types.ts
@@ -1,6 +1,7 @@
 export type Provider =
   | "google"
   | "openai"
+  | "agnes"
   | "openrouter"
   | "dashscope"
   | "zai"
@@ -67,6 +68,7 @@ export type ExtendConfig = {
   default_model: {
     google: string | null;
     openai: string | null;
+    agnes: string | null;
     openrouter: string | null;
     dashscope: string | null;
     zai: string | null;


### PR DESCRIPTION
## Summary

This PR adds a first-class Agnes provider to `baoyu-image-gen`, and the latest update hardens the implementation after comparing it against the existing upstream Agnes PR and the current Agnes Image 2.1 Flash docs.

## What’s included

- add `--provider agnes` to `baoyu-image-gen`
- support Agnes text-to-image with `agnes-image-2.1-flash`
- support Agnes image-to-image via `--ref`
- support `--response-format url` for Agnes, which writes the returned image URL into a `.txt` file
- wire model/env/config handling:
  - `AGNES_API_KEY`
  - `AGNES_IMAGE_MODEL`
  - `AGNES_BASE_URL`
  - `default_model.agnes`
- add provider auto-detection and batch rate-limit config support
- add provider docs / README / usage examples / preference schema updates
- add unit tests for the provider and the main provider-selection flow

## Follow-up fixes in this branch

Compared with the earlier revision of this PR, I added a follow-up commit that:

- fixes remote `--ref https://...` handling for Agnes auto-detection in both single and batch mode
- keeps the Agnes request shape aligned with the current docs / live-tested path:
  - text-to-image Base64 via top-level `return_base64: true`
  - image-to-image refs via `extra_body.image[]`
  - URL output via `extra_body.response_format: \"url\"`
- includes HTTP status codes in Agnes API errors so non-retryable 4xx responses are classified correctly in batch mode
- updates docs and examples to reflect the final behavior

## Verification

I verified this in four ways:

- `npm test` (`243` pass, `0` fail)
- direct provider unit tests for the Agnes module
- targeted regressions for:
  - auto-detected Agnes with remote HTTPS refs in single mode
  - auto-detected Agnes with remote HTTPS refs in batch mode
  - `--response-format url` propagation through CLI/provider flow
  - Agnes 4xx API errors carrying HTTP status codes
- local live API smoke tests with a real Agnes API key:
  - text-to-image end-to-end through `skills/baoyu-image-gen/scripts/main.ts`
  - image-to-image (`--ref`) end-to-end through the same CLI flow

## Small dependency fix included

I also kept the separate prerequisite commit adding the missing `socks` dependency.

`origin/main` currently imports `socks` from `skills/baoyu-post-to-wechat/scripts/wechat-socks-http.ts`, but the root package manifest does not declare it, so a clean `npm test` fails before/alongside feature work.

If you would prefer, I’m happy to split that dependency fix into a separate PR.