### PR TITLE
fix(baoyu-fetch): parse YouTube /embed/ URLs in parseYouTubeVideoId

### DIFF
--- a/packages/baoyu-fetch/src/__tests__/youtube-utils.test.ts
+++ b/packages/baoyu-fetch/src/__tests__/youtube-utils.test.ts
@@ -19,6 +19,10 @@ describe("parseYouTubeVideoId", () => {
   test("parses shorts URLs", () => {
     expect(parseYouTubeVideoId(new URL("https://www.youtube.com/shorts/abc123"))).toBe("abc123");
   });
+
+  test("parses embed URLs", () => {
+    expect(parseYouTubeVideoId(new URL("https://www.youtube.com/embed/abc123"))).toBe("abc123");
+  });
 });
 
 describe("parseYouTubeDescriptionChapters", () => {

--- a/packages/baoyu-fetch/src/adapters/youtube/utils.ts
+++ b/packages/baoyu-fetch/src/adapters/youtube/utils.ts
@@ -52,6 +52,11 @@ export function parseYouTubeVideoId(url: URL): string | null {
     return liveMatch[1];
   }
 
+  const embedMatch = url.pathname.match(/^\/embed\/([^/?#]+)/);
+  if (embedMatch) {
+    return embedMatch[1];
+  }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary

`parseYouTubeVideoId` (`packages/baoyu-fetch/src/adapters/youtube/utils.ts`)
recognizes `watch`, `youtu.be`, `/shorts/`, and `/live/` URLs but **not the
`/embed/<id>` player form**, which is the most common shape for embedded
YouTube links. For an embed URL it returns `null`, so the YouTube adapter
falls through to `no_document` and the video is never processed.

## Fix

Add an `/embed/` branch that mirrors the existing `/shorts/` and `/live/`
handling:

```ts
const embedMatch = url.pathname.match(/^\/embed\/([^/?#]+)/);
if (embedMatch) {
  return embedMatch[1];
}
```

## Test

Added a regression case to `youtube-utils.test.ts`:

```ts
test("parses embed URLs", () => {
  expect(parseYouTubeVideoId(new URL("https://www.youtube.com/embed/abc123"))).toBe("abc123");
});
```

It fails before the change (returns `null`) and passes after. Verified locally:

```
bun test packages/baoyu-fetch/src/__tests__/youtube-utils.test.ts
# 10 pass / 0 fail
```
