### PR TITLE
feat(baoyu-youtube-transcript): support cookies file fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 English | [中文](./CHANGELOG.zh.md)
 
+## Unreleased
+
+### Features
+- `baoyu-youtube-transcript`: support Netscape-format cookies files during yt-dlp fallback via `YOUTUBE_TRANSCRIPT_COOKIES_FILE`
+
 ## 2.5.1 - 2026-06-13
 
 ### Documentation

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -2,6 +2,11 @@
 
 [English](./CHANGELOG.md) | 中文
 
+## Unreleased
+
+### 新功能
+- `baoyu-youtube-transcript`：支持通过 `YOUTUBE_TRANSCRIPT_COOKIES_FILE` 在 yt-dlp 回退时传入 Netscape 格式 cookies 文件
+
 ## 2.5.1 - 2026-06-13
 
 ### 文档

--- a/skills/baoyu-youtube-transcript/SKILL.md
+++ b/skills/baoyu-youtube-transcript/SKILL.md
@@ -79,6 +79,7 @@ ${BUN_X} {baseDir}/scripts/main.ts <url> --refresh
 
 | Variable | Description |
 |----------|-------------|
+| `YOUTUBE_TRANSCRIPT_COOKIES_FILE` | Passed to `yt-dlp --cookies` during fallback. Use a Netscape-format cookies file exported from a browser or another trusted source. Takes precedence over `YOUTUBE_TRANSCRIPT_COOKIES_FROM_BROWSER` |
 | `YOUTUBE_TRANSCRIPT_COOKIES_FROM_BROWSER` | Passed to `yt-dlp --cookies-from-browser` during fallback, e.g. `chrome`, `safari`, `firefox`, or `chrome:Profile 1` |
 
 ## Input Formats
@@ -183,4 +184,4 @@ When `--speakers` is used, `--chapters` is implied — the processed output alwa
 | Video unavailable | Video deleted, private, or region-locked |
 | IP blocked | Too many requests, try again later |
 | Age restricted | Video requires login for age verification |
-| bot detected | The script retries alternate clients and then `yt-dlp`; if fallback tooling is missing, the agent should resolve that itself, otherwise if it still fails try `YOUTUBE_TRANSCRIPT_COOKIES_FROM_BROWSER=safari` (or your browser) |
+| bot detected | The script retries alternate clients and then `yt-dlp`; if fallback tooling is missing, the agent should resolve that itself, otherwise if it still fails try `YOUTUBE_TRANSCRIPT_COOKIES_FILE=/path/to/cookies.txt` or `YOUTUBE_TRANSCRIPT_COOKIES_FROM_BROWSER=safari` (or your browser) |

--- a/skills/baoyu-youtube-transcript/scripts/youtube.ts
+++ b/skills/baoyu-youtube-transcript/scripts/youtube.ts
@@ -374,8 +374,10 @@ function fetchYtDlpInfo(videoId: string): YtDlpInfo {
     "--remote-components",
     "ejs:github",
   ];
+  const cookiesFile = process.env.YOUTUBE_TRANSCRIPT_COOKIES_FILE?.trim();
   const cookiesFromBrowser = process.env.YOUTUBE_TRANSCRIPT_COOKIES_FROM_BROWSER?.trim();
-  if (cookiesFromBrowser) args.push("--cookies-from-browser", cookiesFromBrowser);
+  if (cookiesFile) args.push("--cookies", cookiesFile);
+  else if (cookiesFromBrowser) args.push("--cookies-from-browser", cookiesFromBrowser);
   args.push(`${WATCH_URL}${videoId}`);
 
   const result = spawnSync(command.command, args, {


### PR DESCRIPTION
## Summary
- add YOUTUBE_TRANSCRIPT_COOKIES_FILE for yt-dlp fallback with Netscape-format cookies files
- prefer explicit cookies files over cookies-from-browser when both are configured
- document the new environment variable and update changelogs

## Test
- bun test skills/baoyu-youtube-transcript/scripts/main.test.ts