### PR TITLE
fix(baoyu-xhs-images): include skill slug in top H1

### DIFF
--- a/skills/baoyu-xhs-images/SKILL.md
+++ b/skills/baoyu-xhs-images/SKILL.md
@@ -7,7 +7,7 @@ metadata:
     homepage: https://github.com/JimLiu/baoyu-skills#baoyu-xhs-images
 ---
 
-# Image Card Series Generator
+# baoyu-xhs-images: Image Card Series Generator
 
 Break down complex content into eye-catching image card series with multiple style options.
 


### PR DESCRIPTION
Fixes #183.

The skill's name (`baoyu-xhs-images`) and H1 (`Image Card Series Generator`) shared no common stem. This patch prefixes the H1 with the skill slug: `# baoyu-xhs-images: Image Card Series Generator`. One-line rename.