### PR TITLE
fix(gemini-web): recover generated images on Gemini 3

### DIFF
--- a/skills/baoyu-danger-gemini-web/scripts/gemini-webapi/client.ts
+++ b/skills/baoyu-danger-gemini-web/scripts/gemini-webapi/client.ts
@@ -456,19 +456,19 @@ export class GeminiClient extends GemMixin {
           const generated_images: GeneratedImage[] = [];
           const wants_generated =
             get_nested_value(candidate, [12, 7, 0], null) != null ||
-            /http:\/\/googleusercontent\.com\/image_generation_content\/\d+/.test(text);
+            /http:\/\/googleusercontent\.com\/image_generation_content\/\d+/.test(text) ||
+            // Gemini 3 no longer emits the legacy marker in the candidate text; the generated
+            // image arrives in a later response part. Detect it from the raw response instead.
+            /\/gg-dl\//.test(txt) ||
+            /image_generation_content\/\d+/.test(txt);
 
           if (wants_generated) {
             const image_part = find_generated_image_part(response_json as unknown[], body_index, candidate_index, 1);
             const img_body = image_part?.body ?? null;
 
-            if (!img_body) {
-              throw new ImageGenerationError(
-                'Failed to parse generated images. Please update gemini_webapi to the latest version. If the error persists and is caused by the package, please report it on GitHub.',
-              );
-            }
-
-            const img_candidate = get_nested_value<unknown[]>(img_body, [4, candidate_index], []);
+            // Not every candidate carries a generated image (e.g. multi-candidate responses).
+            // If this candidate has no image part, skip extraction instead of failing the whole call.
+            const img_candidate = img_body ? get_nested_value<unknown[]>(img_body, [4, candidate_index], []) : [];
             const finished = get_nested_value<string | null>(img_candidate, [1, 0], null);
             if (finished) {
               text = finished.replace(/http:\/\/googleusercontent\.com\/image_generation_content\/\d+/g, '').trimEnd();


### PR DESCRIPTION
## Problem

`baoyu-danger-gemini-web` image generation silently returns **no image** on Gemini 3 (the current default web model). `generate_content(..., --image)` fails with `No image returned in response.` even though the generated image is actually produced and its URL is present in the raw response.

## Root cause

Gemini 3 changed the response shape for generated images:

- It no longer emits the legacy `http://googleusercontent.com/image_generation_content/<n>` marker inside the **candidate text**.
- The generated image now arrives in a **later response part**, and the candidate's `[12][7][0]` field is `null`.

The parser gates all image extraction behind `wants_generated`, which only checks the candidate text and `[12][7][0]`:

```js
const wants_generated =
  get_nested_value(candidate, [12, 7, 0], null) != null ||
  /http:\/\/googleusercontent\.com\/image_generation_content\/\d+/.test(text);
```

On Gemini 3 both checks are false, so `wants_generated` is never true and the whole extraction block is skipped — the `gg-dl/...` image URL sitting in the raw response is never read, and the call returns empty (no error).

I confirmed this by dumping the raw `generate_content` response for `生成一张橘猫... 的手绘插画`: the response contains the `https://lh3.googleusercontent.com/gg-dl/...` URL and `image_generation_content` markers, while `candidate.text` is empty and `candidate[12][7][0]` is null.

## Fix

Two small changes in `skills/baoyu-danger-gemini-web/scripts/gemini-webapi/client.ts`:

1. **Broaden `wants_generated`** to also fire when the raw response (`txt`) contains a `gg-dl/` generated-image URL or an `image_generation_content` marker — i.e. detect image intent from the actual response, not just the (now-empty) candidate text.
2. **Don't throw when a candidate has no image part.** `find_generated_image_part` already returns `null` for candidates without an image; replacing the `throw new ImageGenerationError(...)` with a guarded `img_candidate = img_body ? ... : []` keeps multi-candidate responses from failing wholesale. (`find_generated_image_part` finds the part for the candidate that does carry the image, so nothing is lost.)

## Verification

Against a live Gemini 3 account, with the default `gemini-3-pro` model:

- **Before:** `--image` → `No image returned in response.`; `--json` → `text: ""`, `images: []` (but `thoughts` show the model reasoning about the illustration).
- **After:** a 1408×768 PNG is saved correctly. Re-ran with a different prompt to confirm it's not a fluke.

Note: image generation is triggered by the prompt asking to "generate" — not by model selection — so this is independent of which Gemini 3 chat model is active.
