### PR TITLE
docs: add Autohand Code install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ If you only need a subset of skills in one project, you do not need to install t
 <project>/.agents/skills/baoyu-post-to-wechat/SKILL.md
 ```
 
+### Autohand Code Install
+
+Autohand Code reads skills from `~/.autohand/skills/` for global installs and `<project>/.autohand/skills/` for project-level installs. Copy or symlink each skill directory you want to expose:
+
+```bash
+# Global install
+mkdir -p ~/.autohand/skills/
+cp -R skills/baoyu-cover-image skills/baoyu-article-illustrator ~/.autohand/skills/
+
+# Project-level install
+mkdir -p .autohand/skills/
+ln -s "$(pwd)/skills/baoyu-post-to-wechat" .autohand/skills/baoyu-post-to-wechat
+```
+
+Autohand Code also supports `autohand --skill-install` for skills listed in the Autohand catalog, with `--project` for workspace-level installs. Until these skills are cataloged there, use the direct copy or symlink paths above.
+
 For a WeChat Official Account article workflow, the usual minimal set is:
 
 - `baoyu-cover-image`

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,6 +39,22 @@ npx skills add jimliu/baoyu-skills
 <project>/.agents/skills/baoyu-post-to-wechat/SKILL.md
 ```
 
+### Autohand Code 安装
+
+Autohand Code 会从 `~/.autohand/skills/` 读取全局 skill，也会从 `<project>/.autohand/skills/` 读取当前项目的 skill。把需要使用的 skill 目录复制或软链接进去即可：
+
+```bash
+# 全局安装
+mkdir -p ~/.autohand/skills/
+cp -R skills/baoyu-cover-image skills/baoyu-article-illustrator ~/.autohand/skills/
+
+# 项目级安装
+mkdir -p .autohand/skills/
+ln -s "$(pwd)/skills/baoyu-post-to-wechat" .autohand/skills/baoyu-post-to-wechat
+```
+
+Autohand Code 也支持通过 `autohand --skill-install` 安装已收录在 Autohand catalog 中的 skill，并可通过 `--project` 安装到当前项目。在这些 skill 收录前，请使用上面的复制或软链接方式。
+
 公众号文章发布的最小组合通常是：
 
 - `baoyu-cover-image`


### PR DESCRIPTION
## Summary

Adds Autohand Code install notes to the English and Chinese READMEs.

The new sections show users how to expose selected `skills/baoyu-*` directories to Autohand Code using:

- `~/.autohand/skills/` for global installs
- `<project>/.autohand/skills/` for project-level installs

The wording stays conservative by recommending copy or symlink setup until these skills are available through the Autohand skill catalog.

## Validation

- `git diff --check`
- `npm test`

For local validation, I installed root dependencies with `npm ci --cache ../../.npm-cache` and installed the nested WeChat skill dependency with `npm install --no-save --no-package-lock --prefix skills/baoyu-post-to-wechat/scripts socks --cache ../../.npm-cache` so the existing SOCKS tests could resolve that package.
