### PR TITLE
feat(baoyu-image-gen): .env files now override process.env

### DIFF
--- a/skills/baoyu-image-gen/SKILL.md
+++ b/skills/baoyu-image-gen/SKILL.md
@@ -152,7 +152,7 @@ When the user wants a person/object preserved from reference images:
 | `BAOYU_CODEX_IMAGEGEN_RETRIES` | Wrapper-side retry attempts on retryable errors for the `codex-cli` provider (default: 2) |
 | `BAOYU_CODEX_IMAGEGEN_LOG_FILE` | Append JSONL diagnostic log for the `codex-cli` provider |
 
-**Load priority**: CLI args > EXTEND.md > env vars > `<cwd>/.baoyu-skills/.env` > `~/.baoyu-skills/.env`
+**Load priority**: CLI args > EXTEND.md > `<cwd>/.baoyu-skills/.env` > `~/.baoyu-skills/.env` > env vars
 
 ### Codex/ChatGPT OAuth is not an OpenAI API key
 

--- a/skills/baoyu-image-gen/scripts/main.ts
+++ b/skills/baoyu-image-gen/scripts/main.ts
@@ -165,7 +165,7 @@ Environment variables:
   BAOYU_CODEX_IMAGEGEN_RETRIES  Codex-side retry attempts on retryable errors (default: 2)
   BAOYU_CODEX_IMAGEGEN_LOG_FILE  Append JSONL diagnostic log for codex-cli provider
 
-Env file load order: CLI args > EXTEND.md > process.env > <cwd>/.baoyu-skills/.env > ~/.baoyu-skills/.env`);
+Env file load order: CLI args > EXTEND.md > <cwd>/.baoyu-skills/.env > ~/.baoyu-skills/.env > process.env`);
 }
 
 export function parseArgs(argv: string[]): CliArgs {
@@ -389,11 +389,14 @@ async function loadEnv(): Promise<void> {
   const homeEnv = await loadEnvFile(path.join(home, ".baoyu-skills", ".env"));
   const cwdEnv = await loadEnvFile(path.join(cwd, ".baoyu-skills", ".env"));
 
+  // Load priority (lowest -> highest wins):
+  //   process.env  <  ~/.baoyu-skills/.env  <  <cwd>/.baoyu-skills/.env
+  // Higher-precedence .env files OVERWRITE values already in process.env.
   for (const [k, v] of Object.entries(homeEnv)) {
-    if (!process.env[k]) process.env[k] = v;
+    process.env[k] = v;
   }
   for (const [k, v] of Object.entries(cwdEnv)) {
-    if (!process.env[k]) process.env[k] = v;
+    process.env[k] = v;
   }
 }
 


### PR DESCRIPTION
## Summary

Reorders the environment-variable load priority in `baoyu-image-gen` so that explicit `.env` config files take precedence over ambient `process.env` (command-line / system environment variables).

**Before**
\`\`\`
CLI args > EXTEND.md > process.env > <cwd>/.baoyu-skills/.env > ~/.baoyu-skills/.env
\`\`\`

**After**
\`\`\`
CLI args > EXTEND.md > <cwd>/.baoyu-skills/.env > ~/.baoyu-skills/.env > process.env
\`\`\`

CLI args and EXTEND.md remain at the top of the stack and are unchanged — only the relative order of `process.env` vs the `.env` files is flipped.

## Motivation

Explicit config files (`.env`) should win over ambient `process.env` so that project-local overrides are predictable and not silently shadowed by whatever the parent shell happens to export. The previous behavior meant a stray exported var in the user's shell would silently override a value the user explicitly wrote into their `.baoyu-skills/.env`, which is surprising and hard to debug.

## Changes

- \`skills/baoyu-image-gen/scripts/main.ts\` — \`loadEnv()\` now writes `.env` values **unconditionally** into \`process.env\` instead of only filling missing keys. User-level \`~/.baoyu-skills/.env\` is applied first, then project-level \`<cwd>/.baoyu-skills/.env\` is applied last so it wins.
- \`skills/baoyu-image-gen/scripts/main.ts\` — help text \`Env file load order\` updated.
- \`skills/baoyu-image-gen/SKILL.md\` — \`Load priority\` line updated.

## Test plan

- [x] Existing test suite passes: \`bun test scripts/main.test.ts\` → 21 pass, 0 fail
- [ ] Manual: set \`OPENAI_API_KEY=from-shell\` in shell, put \`OPENAI_API_KEY=from-env-file\` in \`<cwd>/.baoyu-skills/.env\`, run with \`--provider openai\` and confirm the .env value is the one used.

## Notes

- This is a behavioral change. If merged, it should be called out in the changelog / release notes as a possible breaking change for users who relied on shell environment variables overriding their `.env` files.
- Marked as draft for discussion — happy to drop the draft status or adjust scope based on maintainer feedback.