### PR TITLE
fix(baoyu-youtube-transcript): preserve Korean spacing

### DIFF
--- a/skills/baoyu-youtube-transcript/scripts/main.test.ts
+++ b/skills/baoyu-youtube-transcript/scripts/main.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { findTranscript, parseTranscriptJson3, parseWebVtt } from "./transcript.ts";
+import { findTranscript, parseTranscriptJson3, parseWebVtt, segmentIntoSentences } from "./transcript.ts";
 import { buildTranscriptListFromYtDlp, fetchTranscriptWithFallback, resolveVideoSource, selectYtDlpTrack } from "./youtube.ts";
 
 test("selectYtDlpTrack prefers json3 over xml and vtt", () => {
@@ -180,4 +180,29 @@ test("fetchTranscriptWithFallback retries with yt-dlp when InnerTube transcript 
   assert.equal(result.snippets.length, 1);
   assert.equal(result.snippets[0].text, "Recovered subtitle");
   assert.match(warnings[0] || "", /Retrying with yt-dlp fallback/);
+});
+
+test("segmentIntoSentences preserves spaces between Korean snippets", () => {
+  const sentences = segmentIntoSentences([
+    { text: "저희는", start: 0, duration: 1 },
+    { text: "그런 문제점을", start: 1, duration: 1 },
+    { text: "해결했습니다.", start: 2, duration: 1 },
+  ]);
+
+  assert.equal(sentences[0].text, "저희는 그런 문제점을 해결했습니다.");
+});
+
+test("segmentIntoSentences keeps Chinese and Japanese snippets unspaced", () => {
+  const chinese = segmentIntoSentences([
+    { text: "我们", start: 0, duration: 1 },
+    { text: "解决了", start: 1, duration: 1 },
+    { text: "问题。", start: 2, duration: 1 },
+  ]);
+  const japanese = segmentIntoSentences([
+    { text: "これは", start: 0, duration: 1 },
+    { text: "テストです。", start: 1, duration: 1 },
+  ]);
+
+  assert.equal(chinese[0].text, "我们解决了问题。");
+  assert.equal(japanese[0].text, "これはテストです。");
 });

--- a/skills/baoyu-youtube-transcript/scripts/transcript.ts
+++ b/skills/baoyu-youtube-transcript/scripts/transcript.ts
@@ -99,12 +99,11 @@ export function parseTranscriptPayload(payload: string, url: string): Snippet[] 
   return parseTranscriptXml(payload);
 }
 
-function isCJK(ch: string): boolean {
+function isUnspacedCJK(ch: string): boolean {
   const code = ch.charCodeAt(0);
   return (code >= 0x4E00 && code <= 0x9FFF) ||
     (code >= 0x3040 && code <= 0x309F) ||
     (code >= 0x30A0 && code <= 0x30FF) ||
-    (code >= 0xAC00 && code <= 0xD7AF) ||
     (code >= 0x3400 && code <= 0x4DBF) ||
     (code >= 0xF900 && code <= 0xFAFF);
 }
@@ -152,7 +151,7 @@ function mergeTexts(texts: string[]): string {
     if (!next) continue;
     const lastChar = result[result.length - 1];
     const firstChar = next[0];
-    if (isCJK(lastChar) || isCJK(firstChar)) {
+    if (isUnspacedCJK(lastChar) || isUnspacedCJK(firstChar)) {
       result += next;
     } else {
       result = result.trimEnd() + " " + next.trimStart();


### PR DESCRIPTION
## Summary

- preserve spaces when sentence segmentation merges Korean transcript snippets
- keep the existing no-space joining behavior for Chinese and Japanese scripts
- add focused regression coverage for all three languages

## Reproduction

Before this change, adjacent Korean snippets such as:

```text
저희는 + 그런 문제점을 + 해결했습니다.
```

were merged as:

```text
저희는그런 문제점을해결했습니다.
```

Hangul syllables were included in the same no-space boundary check as Han, Hiragana, and Katakana. This change limits that check to scripts that are written without inter-word spaces.

## Tests

- `node --import tsx --test skills/baoyu-youtube-transcript/scripts/main.test.ts` — 9 passed
- `npm test` — 251 passed
