### PR TITLE
fix(wechat): accept URL covers and cover_image frontmatter key

### DIFF
--- a/skills/baoyu-post-to-wechat/SKILL.md
+++ b/skills/baoyu-post-to-wechat/SKILL.md
@@ -184,7 +184,7 @@ Ask method unless specified in EXTEND.md or CLI:
 
 Auto-generation: title = first H1/H2 or first sentence; summary = first paragraph, truncated to 120 chars.
 
-4. **Cover image** (required for API `article_type=news`): CLI `--cover` → frontmatter (`coverImage` / `featureImage` / `cover` / `image`) → `imgs/cover.png` → first inline image → stop and request one if still missing.
+4. **Cover image** (required for API `article_type=news`): CLI `--cover` → frontmatter (`coverImage` / `featureImage` / `cover_image` / `cover` / `image`) → `imgs/cover.png` → first inline image → stop and request one if still missing. Local paths and `http(s)://` URLs are both accepted.
 
 ### Step 4: Publish
 

--- a/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
@@ -504,7 +504,7 @@ Frontmatter Fields (markdown):
   author              Author name
   digest/summary      Article summary
   sourceUrl/contentSourceUrl/content_source_url   Original article URL
-  coverImage/featureImage/cover/image   Cover image path
+  coverImage/featureImage/cover_image/cover/image   Cover image path (local path or URL)
 
 Comments:
   Comments are enabled by default, open to all users.
@@ -797,9 +797,11 @@ async function main(): Promise<void> {
   const rawCoverPath = args.cover ||
     frontmatter.coverImage ||
     frontmatter.featureImage ||
+    frontmatter.cover_image ||
     frontmatter.cover ||
     frontmatter.image;
-  const coverPath = rawCoverPath && !path.isAbsolute(rawCoverPath) && args.cover
+  const isRemoteUrl = (p: string) => /^https?:\/\//i.test(p);
+  const coverPath = rawCoverPath && !isRemoteUrl(rawCoverPath) && !path.isAbsolute(rawCoverPath) && args.cover
     ? path.resolve(process.cwd(), rawCoverPath)
     : rawCoverPath;
   const needNewsCoverFallback = args.articleType === "news" && !coverPath;


### PR DESCRIPTION
Two small cover-resolution bugs in `baoyu-post-to-wechat`, both hit while publishing an article whose images live on a CDN.

## 1. `--cover <url>` fails with "Image not found"

`wechat-api.ts` resolves the cover path like this:

```ts
const coverPath = rawCoverPath && !path.isAbsolute(rawCoverPath) && args.cover
  ? path.resolve(process.cwd(), rawCoverPath)
  : rawCoverPath;
```

`path.isAbsolute()` returns `false` for a URL, so a remote cover gets run through `path.resolve()`:

```
--cover https://img.example.com/cover.jpg
  => /work/https:/img.example.com/cover.jpg   ❌
```

This is purely a caller-side problem — the downstream loader already handles remote inputs:

```ts
// wechat-image-loader.ts:33
if (imagePath.startsWith("http://") || imagePath.startsWith("https://")) {
  const response = await fetch(imagePath);
```

and the CLI help already advertises URL support (`--cover <path>  Cover image path (local or URL)`). So the fix is just to skip path resolution when the value is a URL.

## 2. `cover_image` frontmatter key is not recognized

The lookup chain accepts `coverImage` / `featureImage` / `cover` / `image`, but not snake_case `cover_image`. Authors using that key silently get no cover and have to pass `--cover` by hand.

This mirrors how `content_source_url` is already accepted alongside `contentSourceUrl`, so accepting `cover_image` keeps the frontmatter conventions consistent.

## Changes

- Skip `path.resolve()` for `http(s)://` covers (case-insensitive).
- Add `frontmatter.cover_image` to the lookup chain, after the camelCase variants so existing precedence is unchanged.
- Update the CLI help text and `SKILL.md` to document both.

## Verification

Reproduced the original failure and confirmed each case against the patched logic:

| Input | Before | After |
|---|---|---|
| `--cover https://…/cover.jpg` | `/work/https:/img…` ❌ | unchanged ✅ |
| `--cover http://a.com/x.png` | mangled ❌ | unchanged ✅ |
| `--cover HTTPS://a.com/x.png` | mangled ❌ | unchanged ✅ |
| `--cover cover.png` | `/work/cover.png` | `/work/cover.png` ✅ |
| `--cover /abs/c.png` | `/abs/c.png` | `/abs/c.png` ✅ |
| frontmatter URL (no `--cover`) | unchanged | unchanged ✅ |
| frontmatter relative (no `--cover`) | unchanged | unchanged ✅ |
| `cover_image: <url>` | not picked up ❌ | picked up ✅ |

Local-path and no-`--cover` behavior is untouched. `bun build` parses the modified file cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)