### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1393,4 +1393,4 @@ Published ClawHub skills follow ClawHub registry rules and are distributed under
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JimLiu/baoyu-skills&type=Date)](https://www.star-history.com/#JimLiu/baoyu-skills&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JimLiu/baoyu-skills&type=Date)](https://star-history.dera.page/#JimLiu/baoyu-skills&type=Date)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1394,4 +1394,4 @@ HTTP_PROXY=http://127.0.0.1:7890 HTTPS_PROXY=http://127.0.0.1:7890 /baoyu-danger
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=JimLiu/baoyu-skills&type=Date)](https://www.star-history.com/#JimLiu/baoyu-skills&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=JimLiu/baoyu-skills&type=Date)](https://star-history.dera.page/#JimLiu/baoyu-skills&type=Date)


### PR DESCRIPTION
The Star History chart in the READMEs is currently broken and no longer renders. The old chart endpoint is affected by GitHub stargazer API restrictions, so the chart cannot display. This change switches the chart and its link to the new star history service so the chart works again for all readers.