### PR TITLE
fix(baoyu-fetch): 构建时将 jsdom 设为 external，修复发布产物在他人机器上崩溃

### DIFF
--- a/packages/baoyu-fetch/.changeset/external-jsdom-bundle-fix.md
+++ b/packages/baoyu-fetch/.changeset/external-jsdom-bundle-fix.md
@@ -1,0 +1,5 @@
+---
+"baoyu-fetch": patch
+---
+
+Mark `jsdom` as external in the bundle. Bundling it inlined the build machine's absolute path to `xhr-sync-worker.js`, so the published CLI crashed on any other machine with `Cannot find module .../jsdom/lib/jsdom/living/xhr/xhr-sync-worker.js`.

--- a/packages/baoyu-fetch/package.json
+++ b/packages/baoyu-fetch/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/cli.ts --target bun --outfile ./dist/cli.js && chmod +x ./dist/cli.js",
+    "build": "rm -rf dist && bun build ./src/cli.ts --target bun --external jsdom --outfile ./dist/cli.js && chmod +x ./dist/cli.js",
     "check": "tsc --noEmit",
     "dev": "bun run ./src/cli.ts",
     "release": "changeset publish",


### PR DESCRIPTION
## 问题

npm 上发布的 `baoyu-fetch@0.1.2` 在任何非构建机上运行都会崩溃：

```
$ bunx baoyu-fetch https://cointelegraph.com/news/...
error: Cannot find module '/Users/jimliu/GitHub/baoyu-skills/node_modules/jsdom/lib/jsdom/living/xhr/xhr-sync-worker.js' from '.../node_modules/baoyu-fetch/dist/cli.js'
```

## 根因

`bun build` 将 jsdom 打包进 `dist/cli.js` 时，jsdom 内部 `XMLHttpRequest-impl.js` 的

```js
const syncWorkerFile = require.resolve("./xhr-sync-worker.js");
```

在**构建期**被解析为构建机的绝对路径（`/Users/jimliu/...`）并内联进产物。发布后任何其他机器上一加载 jsdom 就找不到该文件。已确认 0.1.2 的 `dist/cli.js` 中存在这条内联路径。

## 修复

构建命令加 `--external jsdom`，运行时从安装的 `node_modules` 正常解析（jsdom 本就在 `dependencies` 中）。

## 验证

- 重建后 `dist/cli.js` 中不再含构建机绝对路径，jsdom 以外部 import 保留
- `npm install -g` 本地重建版本后，`bunx baoyu-fetch <cointelegraph 文章>` 完整输出 markdown（标题/正文/图片正常）

🤖 Generated with [Claude Code](https://claude.com/claude-code)