### PR TITLE
fix(baoyu-post-to-wechat): reject SVG body images

### DIFF
--- a/skills/baoyu-post-to-wechat/SKILL.md
+++ b/skills/baoyu-post-to-wechat/SKILL.md
@@ -190,6 +190,8 @@ Auto-generation: title = first H1/H2 or first sentence; summary = first paragrap
 
 **Important — never pre-convert markdown to HTML.** Publishing scripts handle the conversion internally and the two methods render images differently: API renders `<img>` tags for upload, browser uses placeholders for paste-and-replace. Passing a pre-converted HTML breaks one or the other.
 
+**Body image format**: WeChat body images do not support SVG; convert SVG files to PNG or JPG before publishing.
+
 **Markdown citation default**: for markdown input, ordinary external links are converted to bottom citations by default. Use `--no-cite` only if the user explicitly wants to keep inline links. Existing HTML input is left as-is.
 
 **API method** (accepts `.md` or `.html`):

--- a/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
+++ b/skills/baoyu-post-to-wechat/scripts/wechat-api.ts
@@ -297,6 +297,7 @@ async function uploadImagesInHtml(
       }
     } catch (err) {
       console.error(`[wechat-api] Failed to upload ${imagePath}:`, err);
+      if (err instanceof Error && err.message.includes("Cannot convert .svg image")) throw err;
     }
   }
 
@@ -331,6 +332,7 @@ async function uploadImagesInHtml(
       }
     } catch (err) {
       console.error(`[wechat-api] Failed to upload placeholder ${image.placeholder}:`, err);
+      if (err instanceof Error && err.message.includes("Cannot convert .svg image")) throw err;
     }
   }
 


### PR DESCRIPTION
## Summary

- document that WeChat body images do not support SVG
- stop draft publishing when an unsupported SVG body image is encountered

## Tests

- `cd skills/baoyu-post-to-wechat/scripts && bun test` (39 passed)