### PR TITLE
feat(baoyu-image-gen): update Agnes default image model to agnes-image-2.5-flash

### DIFF
--- a/skills/baoyu-image-gen/SKILL.md
+++ b/skills/baoyu-image-gen/SKILL.md
@@ -207,7 +207,7 @@ Each provider has its own quirks (model families, size rules, ref support, limit
 | OpenRouter (multimodal models, `/chat/completions` flow) | `references/providers/openrouter.md` |
 | Replicate (nano-banana, Seedream, Wan) | `references/providers/replicate.md` |
 | Codex CLI (wraps bundled `scripts/codex-imagegen/`; Codex login, no `OPENAI_API_KEY`) | `references/providers/codex-cli.md` |
-| Agnes (agnes-image-2.1-flash, reference-image support) | `references/providers/agnes.md` |
+| Agnes (agnes-image-2.5-flash, reference-image support) | `references/providers/agnes.md` |
 
 ## Provider Selection
 
@@ -282,7 +282,7 @@ If `--provider openai --model gpt-image-2` fails because `OPENAI_API_KEY` is mis
 | `references/providers/minimax.md` | MiniMax image-01 + subject reference |
 | `references/providers/openrouter.md` | OpenRouter multimodal flow |
 | `references/providers/replicate.md` | Replicate supported families + guardrails |
-| `references/providers/agnes.md` | Agnes (agnes-image-2.1-flash) sizing, refs, and limits |
+| `references/providers/agnes.md` | Agnes (agnes-image-2.5-flash) sizing, refs, and limits |
 | `references/config/preferences-schema.md` | EXTEND.md schema |
 | `references/config/first-time-setup.md` | First-time setup flow |
 

--- a/skills/baoyu-image-gen/references/config/preferences-schema.md
+++ b/skills/baoyu-image-gen/references/config/preferences-schema.md
@@ -31,7 +31,7 @@ default_model:
   minimax: null             # e.g., "image-01"
   replicate: null           # e.g., "google/nano-banana-2"
   codex-cli: null           # Logical label only — Codex image_gen has no user-selectable model. Default: "codex-image-gen"
-  agnes: null               # e.g., "agnes-image-2.1-flash"
+  agnes: null               # e.g., "agnes-image-2.5-flash"
 
 batch:
   max_workers: 10
@@ -123,7 +123,7 @@ default_model:
   zai: "glm-image"
   minimax: "image-01"
   replicate: "google/nano-banana-2"
-  agnes: "agnes-image-2.1-flash"
+  agnes: "agnes-image-2.5-flash"
 batch:
   max_workers: 10
   provider_limits:

--- a/skills/baoyu-image-gen/references/providers/agnes.md
+++ b/skills/baoyu-image-gen/references/providers/agnes.md
@@ -1,10 +1,10 @@
 # Sapiens AI Agnes Image
 
-Read when the user picks `--provider agnes` or sets `default_model.agnes`. Default model is `agnes-image-2.1-flash`.
+Read when the user picks `--provider agnes` or sets `default_model.agnes`. Default model is `agnes-image-2.5-flash`.
 
 ## Models
 
-**`agnes-image-2.1-flash`** (only model)
+**`agnes-image-2.5-flash`** (only model)
 
 - Text-to-image and image-to-image (with `--ref`) in a single `/images/generations` endpoint
 - Supports reference images as public URLs or Data URI (base64)

--- a/skills/baoyu-image-gen/scripts/providers/agnes.test.ts
+++ b/skills/baoyu-image-gen/scripts/providers/agnes.test.ts
@@ -111,26 +111,26 @@ test("resolveSize aligns to 32 and respects max edge", () => {
 
 test("validateArgs rejects --n > 1", () => {
   assert.throws(
-    () => validateArgs("agnes-image-2.1-flash", makeArgs({ n: 2 })),
+    () => validateArgs("agnes-image-2.5-flash", makeArgs({ n: 2 })),
     /returns a single image per request/,
   );
   assert.doesNotThrow(() =>
-    validateArgs("agnes-image-2.1-flash", makeArgs({ n: 1 })),
+    validateArgs("agnes-image-2.5-flash", makeArgs({ n: 1 })),
   );
 });
 
 test("buildRequestBody maps prompt, model, size, and reference images", () => {
-  const body = buildRequestBody("a cat", "agnes-image-2.1-flash", {
+  const body = buildRequestBody("a cat", "agnes-image-2.5-flash", {
     size: "1024x1024",
     aspectRatio: null,
     referenceImages: [],
   });
-  assert.equal(body.model, "agnes-image-2.1-flash");
+  assert.equal(body.model, "agnes-image-2.5-flash");
   assert.equal(body.prompt, "a cat");
   assert.equal(body.size, "1024x1024");
   assert.deepEqual(body.extra_body, { response_format: "url" });
 
-  const bodyWithRef = buildRequestBody("a cat", "agnes-image-2.1-flash", {
+  const bodyWithRef = buildRequestBody("a cat", "agnes-image-2.5-flash", {
     size: null,
     aspectRatio: "3:4",
     referenceImages: ["https://example.com/ref.jpg"],

--- a/skills/baoyu-image-gen/scripts/providers/agnes.ts
+++ b/skills/baoyu-image-gen/scripts/providers/agnes.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { CliArgs } from "../types";
 
-const DEFAULT_MODEL = "agnes-image-2.1-flash";
+const DEFAULT_MODEL = "agnes-image-2.5-flash";
 const DEFAULT_BASE_URL = "https://apihub.agnes-ai.com/v1";
 const DEFAULT_SIZE = "1024x1024";
 


### PR DESCRIPTION
### Summary

Update the default model for the Agnes image generation provider from `agnes-image-2.1-flash` to `agnes-image-2.5-flash`.

### Changes

- `skills/baoyu-image-gen/scripts/providers/agnes.ts`: update `DEFAULT_MODEL` constant to `agnes-image-2.5-flash`
- `skills/baoyu-image-gen/scripts/providers/agnes.test.ts`: update test fixtures and assertions to verify `agnes-image-2.5-flash`
- `skills/baoyu-image-gen/references/providers/agnes.md`: update default model description and model documentation
- `skills/baoyu-image-gen/references/config/preferences-schema.md`: update default model comments and full schema example
- `skills/baoyu-image-gen/SKILL.md`: update model references in provider tables

### Verification

- Run unit tests: `node --import tsx --test skills/baoyu-image-gen/scripts/providers/agnes.test.ts` (13 tests passed)
- Run bun tests: `bun test skills/baoyu-image-gen/scripts/providers/agnes.test.ts` (13 tests passed)